### PR TITLE
Add attachment support across chats, boards, and files

### DIFF
--- a/Wired 3/Connection/ConnectionController.swift
+++ b/Wired 3/Connection/ConnectionController.swift
@@ -1697,10 +1697,11 @@ final class ConnectionController {
                     if let chat = await runtime.chat(withID: chatID) {
                         if let user = await chat.users.first(where: { $0.id == userID }) {
                             if let say = message.string(forField: "wired.chat.say") {
+                                let attachments = ChatAttachmentDescriptor.descriptors(from: message)
                                 await MainActor.run {
                                     runtime.clearIncomingChatTyping(chatID: chatID, userID: userID)
                                     appendChatMessage(
-                                        ChatEvent(chat: chat, user: user, type: .say, text: say),
+                                        ChatEvent(chat: chat, user: user, type: .say, text: say, attachments: attachments),
                                         to: chat,
                                         runtime: runtime
                                     )
@@ -1748,10 +1749,11 @@ final class ConnectionController {
                     if let chat = await runtime.chat(withID: chatID) {
                         if let user = await chat.users.first(where: { $0.id == userID }) {
                             if let say = message.string(forField: "wired.chat.me") {
+                                let attachments = ChatAttachmentDescriptor.descriptors(from: message)
                                 await MainActor.run {
                                     runtime.clearIncomingChatTyping(chatID: chatID, userID: userID)
                                     appendChatMessage(
-                                        ChatEvent(chat: chat, user: user, type: .me, text: say),
+                                        ChatEvent(chat: chat, user: user, type: .me, text: say, attachments: attachments),
                                         to: chat,
                                         runtime: runtime
                                     )
@@ -1804,9 +1806,10 @@ final class ConnectionController {
         case "wired.message.message":
             if let senderUserID = message.uint32(forField: "wired.user.id"),
                let body = message.string(forField: "wired.message.message") {
+                let attachments = ChatAttachmentDescriptor.descriptors(from: message)
                 await MainActor.run {
                     guard senderUserID != runtime.userID else { return }
-                    runtime.receivePrivateMessage(from: senderUserID, text: body)
+                    runtime.receivePrivateMessage(from: senderUserID, text: body, attachments: attachments)
                     let sender = runtime.messageConversations.first(where: {
                         $0.kind == .direct && $0.participantUserID == senderUserID
                     })?.title ?? "User"

--- a/Wired 3/Connection/ConnectionController.swift
+++ b/Wired 3/Connection/ConnectionController.swift
@@ -1922,6 +1922,7 @@ final class ConnectionController {
                 let threadUUID = message.uuid(forField: "wired.board.thread"),
                 let text = message.string(forField: "wired.board.text")
             else { break }
+            let attachments = ChatAttachmentDescriptor.descriptors(from: message)
             await MainActor.run {
                 if let thread = runtime.thread(uuid: threadUUID) {
                     thread.postsLoaded = false
@@ -1934,7 +1935,8 @@ final class ConnectionController {
                         postDate: thread.postDate,
                         icon: message.data(forField: "wired.user.icon"),
                         isOwn: thread.isOwn,
-                        isThreadBody: true
+                        isThreadBody: true,
+                        attachments: attachments
                     )
                     thread.posts.append(rootPost)
                     runtime.refreshThreadUnreadState(for: thread)
@@ -1952,13 +1954,15 @@ final class ConnectionController {
             let isOwn = message.bool(forField: "wired.board.own_post") ?? false
             let icon = message.data(forField: "wired.user.icon")
             let editDate = message.date(forField: "wired.board.edit_date")
+            let attachments = ChatAttachmentDescriptor.descriptors(from: message)
             await MainActor.run {
                 if let thread = runtime.thread(uuid: threadUUID) {
                     guard !thread.posts.contains(where: { $0.uuid == postUUID }) else { return }
                     let post = BoardPost(uuid: postUUID, threadUUID: threadUUID,
                                         text: text, nick: nick, postDate: postDate,
                                         icon: icon,
-                                        isOwn: isOwn)
+                                        isOwn: isOwn,
+                                        attachments: attachments)
                     if let editDate {
                         post.editDate = editDate
                     }
@@ -2179,6 +2183,7 @@ final class ConnectionController {
                               let text = message.string(forField: "wired.board.text"),
                               let nick = message.string(forField: "wired.user.nick"),
                               let postDate = message.date(forField: "wired.board.post_date") {
+                        let attachments = ChatAttachmentDescriptor.descriptors(from: message)
                         // Remote reply while viewing: append incrementally to avoid full reload.
                         if let existing = thread.posts.first(where: { $0.uuid == postUUID }) {
                             existing.text = text
@@ -2187,6 +2192,7 @@ final class ConnectionController {
                             existing.icon = message.data(forField: "wired.user.icon")
                             existing.isOwn = message.bool(forField: "wired.board.own_post") ?? false
                             existing.editDate = message.date(forField: "wired.board.edit_date")
+                            existing.attachments = attachments
                             if let index = thread.posts.firstIndex(where: { $0 === existing }) {
                                 let post = thread.posts.remove(at: index)
                                 thread.posts.append(post)
@@ -2199,7 +2205,8 @@ final class ConnectionController {
                                 nick: nick,
                                 postDate: postDate,
                                 icon: message.data(forField: "wired.user.icon"),
-                                isOwn: message.bool(forField: "wired.board.own_post") ?? false
+                                isOwn: message.bool(forField: "wired.board.own_post") ?? false,
+                                attachments: attachments
                             )
                             post.editDate = message.date(forField: "wired.board.edit_date")
                             thread.posts.append(post)

--- a/Wired 3/Connection/ConnectionRuntime.swift
+++ b/Wired 3/Connection/ConnectionRuntime.swift
@@ -18,6 +18,50 @@ struct ChatInvitation: Equatable {
     let inviterNick: String?
 }
 
+private extension String {
+    func resolvingDraftAttachmentReferences(using mapping: [String: String]) -> String {
+        var resolved = self
+
+        for (draftID, attachmentID) in mapping {
+            resolved = resolved.replacingOccurrences(
+                of: "attachment://draft/\(draftID)",
+                with: "attachment://\(attachmentID.lowercased())"
+            )
+        }
+
+        let unresolvedPattern = #"!?\[[^\]]*\]\(attachment://draft/[0-9a-fA-F\-]+\)"#
+        if let regex = try? NSRegularExpression(pattern: unresolvedPattern) {
+            let range = NSRange(resolved.startIndex..<resolved.endIndex, in: resolved)
+            resolved = regex.stringByReplacingMatches(in: resolved, options: [], range: range, withTemplate: "")
+        }
+
+        return resolved
+    }
+
+    func removingUnboundAttachmentReferences(allowedAttachmentIDs: Set<String>) -> String {
+        let pattern = #"!?\[[^\]]*\]\(attachment://([0-9a-fA-F\-]+)\)"#
+        guard let regex = try? NSRegularExpression(pattern: pattern) else { return self }
+
+        let source = self
+        let matches = regex.matches(in: source, options: [], range: NSRange(source.startIndex..<source.endIndex, in: source)).reversed()
+        var result = source
+
+        for match in matches {
+            guard match.numberOfRanges >= 2,
+                  let fullRange = Range(match.range(at: 0), in: result),
+                  let idRange = Range(match.range(at: 1), in: source) else {
+                continue
+            }
+
+            let attachmentID = String(source[idRange]).lowercased()
+            guard !allowedAttachmentIDs.contains(attachmentID) else { continue }
+            result.removeSubrange(fullRange)
+        }
+
+        return result
+    }
+}
+
 struct PendingBoardPostScrollTarget: Equatable {
     let threadUUID: String
     let postUUID: String
@@ -2080,12 +2124,34 @@ final class ConnectionRuntime: Identifiable {
         return collected
     }
 
-    private func uploadChatAttachment(_ attachment: ChatDraftAttachment, toChatID chatID: UInt32) async throws -> String {
+    private enum AttachmentUploadScope {
+        case chat(UInt32)
+        case direct(UInt32)
+        case board(String)
+        case thread(String)
+        case post(String)
+    }
+
+    private func uploadAttachment(
+        _ attachment: ChatDraftAttachment,
+        scope: AttachmentUploadScope
+    ) async throws -> String {
         let data = try Data(contentsOf: attachment.fileURL)
         let digest = SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
 
         let create = P7Message(withName: "wired.attachment.create", spec: spec)
-        create.addParameter(field: "wired.chat.id", value: chatID)
+        switch scope {
+        case .chat(let chatID):
+            create.addParameter(field: "wired.chat.id", value: chatID)
+        case .direct(let userID):
+            create.addParameter(field: "wired.user.id", value: userID)
+        case .board(let boardPath):
+            create.addParameter(field: "wired.board.board", value: boardPath)
+        case .thread(let threadUUID):
+            create.addParameter(field: "wired.board.thread", value: threadUUID)
+        case .post(let postUUID):
+            create.addParameter(field: "wired.board.post", value: postUUID)
+        }
         create.addParameter(field: "wired.attachment.name", value: attachment.fileName)
         create.addParameter(field: "wired.attachment.media_type", value: attachment.mediaType)
         create.addParameter(field: "wired.attachment.size", value: UInt64(data.count))
@@ -2141,65 +2207,59 @@ final class ConnectionRuntime: Identifiable {
         return attachmentID
     }
 
-    private func uploadPrivateMessageAttachment(_ attachment: ChatDraftAttachment, toUserID userID: UInt32) async throws -> String {
-        let data = try Data(contentsOf: attachment.fileURL)
-        let digest = SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
+    private func resolvedBoardMessagePayload(
+        text: String,
+        attachments: [ComposerAttachmentItem],
+        uploadScope: AttachmentUploadScope
+    ) async throws -> (text: String, attachmentIDs: [String], descriptors: [ChatAttachmentDescriptor]) {
+        try ComposerAttachmentItem.validateCollection(attachments)
 
-        let create = P7Message(withName: "wired.attachment.create", spec: spec)
-        create.addParameter(field: "wired.user.id", value: userID)
-        create.addParameter(field: "wired.attachment.name", value: attachment.fileName)
-        create.addParameter(field: "wired.attachment.media_type", value: attachment.mediaType)
-        create.addParameter(field: "wired.attachment.size", value: UInt64(data.count))
-        create.addParameter(field: "wired.attachment.sha256", value: digest)
+        let remoteDescriptors = attachments.compactMap(\.descriptor)
+        let localDrafts = attachments.compactMap(\.draftAttachment)
 
-        guard let createResponse = try await send(create) else {
-            throw WiredError(withTitle: "Attachment", message: "No response from server while creating attachment.")
+        var attachmentIDs = remoteDescriptors.map(\.id)
+        attachmentIDs.reserveCapacity(attachments.count)
+
+        var draftIDMap: [String: String] = [:]
+        draftIDMap.reserveCapacity(localDrafts.count)
+
+        for attachment in localDrafts {
+            let attachmentID = try await uploadAttachment(attachment, scope: uploadScope)
+            attachmentIDs.append(attachmentID)
+            draftIDMap[attachment.id.uuidString.lowercased()] = attachmentID
         }
 
-        if createResponse.name == "wired.error" {
-            throw WiredError(message: createResponse)
-        }
-
-        guard createResponse.name == "wired.attachment.created",
-              let attachmentID = createResponse.uuid(forField: "wired.attachment.id") else {
-            throw WiredError(withTitle: "Attachment", message: "Invalid attachment creation response from server.")
-        }
-
-        var offset = 0
-        let chunkSize = 256 * 1024
-
-        while offset < data.count {
-            let upperBound = min(offset + chunkSize, data.count)
-            let chunk = data.subdata(in: offset..<upperBound)
-
-            let upload = P7Message(withName: "wired.attachment.upload", spec: spec)
-            upload.addParameter(field: "wired.attachment.id", value: attachmentID)
-            upload.addParameter(field: "wired.attachment.offset", value: UInt64(offset))
-            upload.addParameter(field: "wired.attachment.data", value: chunk)
-
-            if let uploadResponse = try await send(upload), uploadResponse.name == "wired.error" {
-                throw WiredError(message: uploadResponse)
+        let descriptors = attachments.map { attachment -> ChatAttachmentDescriptor in
+            switch attachment {
+            case .remote(let descriptor):
+                return descriptor
+            case .local(let draft):
+                let resolvedID = draftIDMap[draft.id.uuidString.lowercased()] ?? ""
+                return ChatAttachmentDescriptor(
+                    id: resolvedID,
+                    name: draft.fileName,
+                    mediaType: draft.mediaType,
+                    size: draft.size,
+                    sha256: "",
+                    inlinePreview: draft.isImage,
+                    width: nil,
+                    height: nil
+                )
             }
-
-            offset = upperBound
         }
 
-        let complete = P7Message(withName: "wired.attachment.complete", spec: spec)
-        complete.addParameter(field: "wired.attachment.id", value: attachmentID)
+        let resolvedText = text
+            .resolvingDraftAttachmentReferences(using: draftIDMap)
+            .removingUnboundAttachmentReferences(allowedAttachmentIDs: Set(attachmentIDs.map { $0.lowercased() }))
+        return (resolvedText, attachmentIDs, descriptors)
+    }
 
-        guard let completeResponse = try await send(complete) else {
-            throw WiredError(withTitle: "Attachment", message: "No completion response from server.")
-        }
+    private func uploadChatAttachment(_ attachment: ChatDraftAttachment, toChatID chatID: UInt32) async throws -> String {
+        try await uploadAttachment(attachment, scope: .chat(chatID))
+    }
 
-        if completeResponse.name == "wired.error" {
-            throw WiredError(message: completeResponse)
-        }
-
-        guard completeResponse.name == "wired.attachment.completed" else {
-            throw WiredError(withTitle: "Attachment", message: "Invalid attachment completion response from server.")
-        }
-
-        return attachmentID
+    private func uploadPrivateMessageAttachment(_ attachment: ChatDraftAttachment, toUserID userID: UInt32) async throws -> String {
+        try await uploadAttachment(attachment, scope: .direct(userID))
     }
 
     @MainActor
@@ -2585,24 +2645,49 @@ final class ConnectionRuntime: Identifiable {
         }
     }
 
-    func addThread(toBoard board: Board, subject: String, text: String) async throws {
+    func addThread(
+        toBoard board: Board,
+        subject: String,
+        text: String,
+        attachments: [ComposerAttachmentItem] = []
+    ) async throws {
         try await withBoardNetworkActivity {
+            let payload = try await resolvedBoardMessagePayload(
+                text: text,
+                attachments: attachments,
+                uploadScope: .board(board.path)
+            )
             let m = P7Message(withName: "wired.board.add_thread", spec: spec)
             m.addParameter(field: "wired.board.board", value: board.path)
             m.addParameter(field: "wired.board.subject", value: subject)
-            m.addParameter(field: "wired.board.text", value: text)
+            m.addParameter(field: "wired.board.text", value: payload.text)
+            if !payload.attachmentIDs.isEmpty {
+                m.addParameter(field: "wired.attachment.ids", value: payload.attachmentIDs)
+            }
             if let response = try await send(m), response.name == "wired.error" {
                 throw WiredError(message: response)
             }
         }
     }
 
-    func addPost(toThread thread: BoardThread, text: String) async throws {
+    func addPost(
+        toThread thread: BoardThread,
+        text: String,
+        attachments: [ComposerAttachmentItem] = []
+    ) async throws {
         try await withBoardNetworkActivity {
+            let payload = try await resolvedBoardMessagePayload(
+                text: text,
+                attachments: attachments,
+                uploadScope: .thread(thread.uuid)
+            )
             let m = P7Message(withName: "wired.board.add_post", spec: spec)
             m.addParameter(field: "wired.board.thread", value: thread.uuid)
             m.addParameter(field: "wired.board.subject", value: thread.subject)
-            m.addParameter(field: "wired.board.text", value: text)
+            m.addParameter(field: "wired.board.text", value: payload.text)
+            if !payload.attachmentIDs.isEmpty {
+                m.addParameter(field: "wired.attachment.ids", value: payload.attachmentIDs)
+            }
             if let response = try await send(m), response.name == "wired.error" {
                 throw WiredError(message: response)
             }
@@ -2614,11 +2699,12 @@ final class ConnectionRuntime: Identifiable {
                 let post = BoardPost(
                     uuid: localUUID,
                     threadUUID: thread.uuid,
-                    text: text,
+                    text: payload.text,
                     nick: me?.nick ?? (connection?.nick ?? "Me"),
                     postDate: Date(),
                     icon: me?.icon,
-                    isOwn: true
+                    isOwn: true,
+                    attachments: payload.descriptors
                 )
                 post.isUnread = false
                 thread.posts.append(post)
@@ -2818,12 +2904,26 @@ final class ConnectionRuntime: Identifiable {
         }
     }
 
-    func editThread(uuid: String, subject: String, text: String) async throws {
+    func editThread(
+        uuid: String,
+        subject: String,
+        text: String,
+        attachments: [ComposerAttachmentItem] = [],
+        sendAttachmentIDs: Bool = true
+    ) async throws {
         try await withBoardNetworkActivity {
+            let payload = try await resolvedBoardMessagePayload(
+                text: text,
+                attachments: attachments,
+                uploadScope: .thread(uuid)
+            )
             let m = P7Message(withName: "wired.board.edit_thread", spec: spec)
             m.addParameter(field: "wired.board.thread", value: uuid)
             m.addParameter(field: "wired.board.subject", value: subject)
-            m.addParameter(field: "wired.board.text", value: text)
+            m.addParameter(field: "wired.board.text", value: payload.text)
+            if sendAttachmentIDs && !payload.attachmentIDs.isEmpty {
+                m.addParameter(field: "wired.attachment.ids", value: payload.attachmentIDs)
+            }
             if let response = try await send(m), response.name == "wired.error" {
                 throw WiredError(message: response)
             }
@@ -2841,12 +2941,26 @@ final class ConnectionRuntime: Identifiable {
         }
     }
 
-    func editPost(uuid: String, subject: String, text: String) async throws {
+    func editPost(
+        uuid: String,
+        subject: String,
+        text: String,
+        attachments: [ComposerAttachmentItem] = [],
+        sendAttachmentIDs: Bool = true
+    ) async throws {
         try await withBoardNetworkActivity {
+            let payload = try await resolvedBoardMessagePayload(
+                text: text,
+                attachments: attachments,
+                uploadScope: .post(uuid)
+            )
             let m = P7Message(withName: "wired.board.edit_post", spec: spec)
             m.addParameter(field: "wired.board.post", value: uuid)
             m.addParameter(field: "wired.board.subject", value: subject)
-            m.addParameter(field: "wired.board.text", value: text)
+            m.addParameter(field: "wired.board.text", value: payload.text)
+            if sendAttachmentIDs && !payload.attachmentIDs.isEmpty {
+                m.addParameter(field: "wired.attachment.ids", value: payload.attachmentIDs)
+            }
             if let response = try await send(m), response.name == "wired.error" {
                 throw WiredError(message: response)
             }

--- a/Wired 3/Connection/ConnectionRuntime.swift
+++ b/Wired 3/Connection/ConnectionRuntime.swift
@@ -1257,7 +1257,8 @@ final class ConnectionRuntime: Identifiable {
                             senderIcon: storedMessage.senderIcon,
                             text: storedMessage.text,
                             date: storedMessage.date,
-                            isFromCurrentUser: storedMessage.isFromCurrentUser
+                            isFromCurrentUser: storedMessage.isFromCurrentUser,
+                            attachments: decodeStoredAttachmentDescriptors(from: storedMessage.attachmentDescriptorsData)
                         )
                     }
                 return conversation
@@ -1356,6 +1357,7 @@ final class ConnectionRuntime: Identifiable {
                         text: message.text,
                         date: message.date,
                         isFromCurrentUser: message.isFromCurrentUser,
+                        attachmentDescriptorsData: encodeStoredAttachmentDescriptors(message.attachments),
                         conversation: storedConversation
                     )
                     modelContext.insert(storedMessage)
@@ -1426,6 +1428,16 @@ final class ConnectionRuntime: Identifiable {
         } catch {
             print("[Messages] save failed:", error)
         }
+    }
+
+    private func encodeStoredAttachmentDescriptors(_ descriptors: [ChatAttachmentDescriptor]) -> Data? {
+        guard !descriptors.isEmpty else { return nil }
+        return try? JSONEncoder().encode(descriptors)
+    }
+
+    private func decodeStoredAttachmentDescriptors(from data: Data?) -> [ChatAttachmentDescriptor] {
+        guard let data else { return [] }
+        return (try? JSONDecoder().decode([ChatAttachmentDescriptor].self, from: data)) ?? []
     }
 
     private func persistenceKey() -> String? {

--- a/Wired 3/Connection/ConnectionRuntime.swift
+++ b/Wired 3/Connection/ConnectionRuntime.swift
@@ -9,6 +9,8 @@
 import SwiftUI
 import SwiftData
 import WiredSwift
+import UniformTypeIdentifiers
+import CryptoKit
 
 struct ChatInvitation: Equatable {
     let chatID: UInt32
@@ -102,6 +104,7 @@ final class MessageEvent: Identifiable {
     let text: String
     let date: Date
     let isFromCurrentUser: Bool
+    let attachments: [ChatAttachmentDescriptor]
 
     @ObservationIgnored private var imageURLCacheResolved = false
     @ObservationIgnored private var cachedImageURL: URL?
@@ -121,7 +124,8 @@ final class MessageEvent: Identifiable {
         senderIcon: Data?,
         text: String,
         date: Date = Date(),
-        isFromCurrentUser: Bool
+        isFromCurrentUser: Bool,
+        attachments: [ChatAttachmentDescriptor] = []
     ) {
         self.id = id
         self.senderNick = senderNick
@@ -130,6 +134,7 @@ final class MessageEvent: Identifiable {
         self.text = text
         self.date = date
         self.isFromCurrentUser = isFromCurrentUser
+        self.attachments = attachments
     }
 }
 
@@ -271,7 +276,9 @@ final class ConnectionRuntime: Identifiable {
     var selectedTab: MainTab = .chats
     var selectedChatID: UInt32? = 1
     var chatDrafts: [UInt32: String] = [:]
+    var chatDraftAttachments: [UInt32: [ChatDraftAttachment]] = [:]
     var messageDrafts: [UUID: String] = [:]
+    var messageDraftAttachments: [UUID: [ChatDraftAttachment]] = [:]
     var userID: UInt32 = 0
     var privileges: [String: Any] = [:]
 
@@ -996,24 +1003,49 @@ final class ConnectionRuntime: Identifiable {
         return conversation
     }
 
-    func sendPrivateMessage(_ text: String, in conversation: MessageConversation) async throws {
+    func sendPrivateMessage(_ text: String, in conversation: MessageConversation, attachments: [ChatDraftAttachment] = []) async throws {
         let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return }
+        guard !trimmed.isEmpty || !attachments.isEmpty else { return }
         guard conversation.kind == .direct else { return }
 
         guard let recipientUserID = resolvedRecipientUserID(for: conversation) else {
             throw WiredError(withTitle: "Private Message", message: "User is offline.")
         }
 
+        try ChatDraftAttachment.validateDraftCollection(attachments)
+
+        var attachmentIDs: [String] = []
+        attachmentIDs.reserveCapacity(attachments.count)
+
+        for attachment in attachments {
+            attachmentIDs.append(try await uploadPrivateMessageAttachment(attachment, toUserID: recipientUserID))
+        }
+
         let message = P7Message(withName: "wired.message.send_message", spec: spec)
         message.addParameter(field: "wired.user.id", value: recipientUserID)
         message.addParameter(field: "wired.message.message", value: trimmed)
+        if !attachmentIDs.isEmpty {
+            message.addParameter(field: "wired.attachment.ids", value: attachmentIDs)
+        }
 
         if let response = try await send(message), response.name == "wired.error" {
             throw WiredError(message: response)
         }
 
-        appendOwnPrivateMessage(trimmed, to: conversation)
+        let descriptors = zip(attachments, attachmentIDs).map { attachment, id in
+            ChatAttachmentDescriptor(
+                id: id,
+                name: attachment.fileName,
+                mediaType: attachment.mediaType,
+                size: attachment.size,
+                sha256: "",
+                inlinePreview: attachment.isImage,
+                width: nil,
+                height: nil
+            )
+        }
+
+        appendOwnPrivateMessage(trimmed, attachments: descriptors, to: conversation)
     }
 
     func sendBroadcastMessage(_ text: String) async throws {
@@ -1031,7 +1063,7 @@ final class ConnectionRuntime: Identifiable {
         appendOwnMessage(trimmed, to: conversation, isBroadcast: true)
     }
 
-    func receivePrivateMessage(from userID: UInt32, text: String) {
+    func receivePrivateMessage(from userID: UInt32, text: String, attachments: [ChatAttachmentDescriptor] = []) {
         let sender = onlineUser(withID: userID)
         let nick = sender?.nick ?? "User #\(userID)"
         let icon = sender?.icon
@@ -1044,6 +1076,7 @@ final class ConnectionRuntime: Identifiable {
             fromNick: nick,
             userID: userID,
             icon: icon,
+            attachments: attachments,
             to: conversation
         )
     }
@@ -1118,11 +1151,11 @@ final class ConnectionRuntime: Identifiable {
         onlineUser(for: conversation)?.icon
     }
 
-    private func appendOwnPrivateMessage(_ text: String, to conversation: MessageConversation) {
-        appendOwnMessage(text, to: conversation, isBroadcast: false)
+    private func appendOwnPrivateMessage(_ text: String, attachments: [ChatAttachmentDescriptor] = [], to conversation: MessageConversation) {
+        appendOwnMessage(text, attachments: attachments, to: conversation, isBroadcast: false)
     }
 
-    private func appendOwnMessage(_ text: String, to conversation: MessageConversation, isBroadcast: Bool) {
+    private func appendOwnMessage(_ text: String, attachments: [ChatAttachmentDescriptor] = [], to conversation: MessageConversation, isBroadcast: Bool) {
         let me = onlineUser(withID: userID)
         let nick = me?.nick ?? "You"
         let icon = me?.icon
@@ -1132,7 +1165,8 @@ final class ConnectionRuntime: Identifiable {
                 senderUserID: userID,
                 senderIcon: icon,
                 text: text,
-                isFromCurrentUser: true
+                isFromCurrentUser: true,
+                attachments: attachments
             )
         )
         if selectedMessageConversationID == nil || selectedMessageConversationID == conversation.id {
@@ -1151,6 +1185,7 @@ final class ConnectionRuntime: Identifiable {
         fromNick nick: String,
         userID: UInt32,
         icon: Data?,
+        attachments: [ChatAttachmentDescriptor] = [],
         to conversation: MessageConversation
     ) {
         conversation.messages.append(
@@ -1159,7 +1194,8 @@ final class ConnectionRuntime: Identifiable {
                 senderUserID: userID,
                 senderIcon: icon,
                 text: text,
-                isFromCurrentUser: false
+                isFromCurrentUser: false,
+                attachments: attachments
             )
         )
 
@@ -1868,8 +1904,12 @@ final class ConnectionRuntime: Identifiable {
 
     // MARK: -
 
-    func sendChatMessage( _ chatID: UInt32, _ text: String) async throws -> P7Message? {
+    func sendChatMessage(_ chatID: UInt32, _ text: String, attachments: [ChatDraftAttachment] = []) async throws -> P7Message? {
         if text.starts(with: "/") {
+            if !attachments.isEmpty {
+                throw WiredError(withTitle: "Attachment", message: "Attachments are currently supported only for regular chat messages.")
+            }
+
             if text == ChatCommand.clear.rawValue {
                 await MainActor.run {
                     self.clearChat(chatID)
@@ -1886,13 +1926,268 @@ final class ConnectionRuntime: Identifiable {
                 return try await self.send(message)
             }
         } else {
+            let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty || !attachments.isEmpty else { return nil }
+
+            try ChatDraftAttachment.validateDraftCollection(attachments)
+
+            var attachmentIDs: [String] = []
+            attachmentIDs.reserveCapacity(attachments.count)
+
+            for attachment in attachments {
+                attachmentIDs.append(try await uploadChatAttachment(attachment, toChatID: chatID))
+            }
+
             let message = P7Message(withName: "wired.chat.send_say", spec: spec)
             message.addParameter(field: "wired.chat.id", value: chatID)
-            message.addParameter(field: "wired.chat.say", value: text)
+            message.addParameter(field: "wired.chat.say", value: trimmed)
+            if !attachmentIDs.isEmpty {
+                message.addParameter(field: "wired.attachment.ids", value: attachmentIDs)
+            }
             return try await self.send(message)
         }
 
         return nil
+    }
+
+    func addChatDraftAttachment(_ fileURL: URL, for chatID: UInt32) throws {
+        let attachment = try ChatDraftAttachment(fileURL: fileURL)
+        var attachments = chatDraftAttachments[chatID] ?? []
+
+        guard !attachments.contains(where: { $0.fileURL == attachment.fileURL }) else { return }
+
+        attachments.append(attachment)
+        try ChatDraftAttachment.validateDraftCollection(attachments)
+        chatDraftAttachments[chatID] = attachments
+    }
+
+    func removeChatDraftAttachment(_ attachment: ChatDraftAttachment, for chatID: UInt32) {
+        guard var attachments = chatDraftAttachments[chatID] else { return }
+
+        attachments.removeAll { $0.id == attachment.id }
+
+        if attachments.isEmpty {
+            chatDraftAttachments.removeValue(forKey: chatID)
+        } else {
+            chatDraftAttachments[chatID] = attachments
+        }
+    }
+
+    func clearChatDraftAttachments(for chatID: UInt32) {
+        chatDraftAttachments.removeValue(forKey: chatID)
+    }
+
+    func addMessageDraftAttachment(_ fileURL: URL, for conversationID: UUID) throws {
+        let attachment = try ChatDraftAttachment(fileURL: fileURL)
+        var attachments = messageDraftAttachments[conversationID] ?? []
+
+        guard !attachments.contains(where: { $0.fileURL == attachment.fileURL }) else { return }
+
+        attachments.append(attachment)
+        try ChatDraftAttachment.validateDraftCollection(attachments)
+        messageDraftAttachments[conversationID] = attachments
+    }
+
+    func removeMessageDraftAttachment(_ attachment: ChatDraftAttachment, for conversationID: UUID) {
+        guard var attachments = messageDraftAttachments[conversationID] else { return }
+
+        attachments.removeAll { $0.id == attachment.id }
+
+        if attachments.isEmpty {
+            messageDraftAttachments.removeValue(forKey: conversationID)
+        } else {
+            messageDraftAttachments[conversationID] = attachments
+        }
+    }
+
+    func clearMessageDraftAttachments(for conversationID: UUID) {
+        messageDraftAttachments.removeValue(forKey: conversationID)
+    }
+
+    func imageData(for attachment: ChatAttachmentDescriptor) async throws -> Data {
+        if attachment.inlinePreview {
+            do {
+                return try await previewData(for: attachment)
+            } catch {
+                return try await downloadChatAttachmentData(attachment)
+            }
+        }
+
+        return try await downloadChatAttachmentData(attachment)
+    }
+
+    func previewData(for attachment: ChatAttachmentDescriptor) async throws -> Data {
+        let message = P7Message(withName: "wired.attachment.get_preview", spec: spec)
+        message.addParameter(field: "wired.attachment.id", value: attachment.id)
+
+        guard let response = try await send(message) else {
+            throw WiredError(withTitle: "Attachment", message: "No preview response from server.")
+        }
+
+        if response.name == "wired.error" {
+            throw WiredError(message: response)
+        }
+
+        guard response.name == "wired.attachment.preview",
+              let data = response.data(forField: "wired.attachment.data") else {
+            throw WiredError(withTitle: "Attachment", message: "Invalid preview response from server.")
+        }
+
+        return data
+    }
+
+    func downloadChatAttachmentData(_ attachment: ChatAttachmentDescriptor) async throws -> Data {
+        var offset: UInt64 = 0
+        var collected = Data()
+        var isComplete = false
+
+        while !isComplete {
+            let message = P7Message(withName: "wired.attachment.get_data", spec: spec)
+            message.addParameter(field: "wired.attachment.id", value: attachment.id)
+            message.addParameter(field: "wired.attachment.offset", value: offset)
+            message.addParameter(field: "wired.attachment.length", value: UInt32(256 * 1024))
+
+            guard let response = try await send(message) else {
+                throw WiredError(withTitle: "Attachment", message: "No data response from server.")
+            }
+
+            if response.name == "wired.error" {
+                throw WiredError(message: response)
+            }
+
+            guard response.name == "wired.attachment.data",
+                  let chunk = response.data(forField: "wired.attachment.data") else {
+                throw WiredError(withTitle: "Attachment", message: "Invalid attachment data response from server.")
+            }
+
+            collected.append(chunk)
+            offset += UInt64(chunk.count)
+            isComplete = response.bool(forField: "wired.attachment.complete") ?? false
+        }
+
+        return collected
+    }
+
+    private func uploadChatAttachment(_ attachment: ChatDraftAttachment, toChatID chatID: UInt32) async throws -> String {
+        let data = try Data(contentsOf: attachment.fileURL)
+        let digest = SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
+
+        let create = P7Message(withName: "wired.attachment.create", spec: spec)
+        create.addParameter(field: "wired.chat.id", value: chatID)
+        create.addParameter(field: "wired.attachment.name", value: attachment.fileName)
+        create.addParameter(field: "wired.attachment.media_type", value: attachment.mediaType)
+        create.addParameter(field: "wired.attachment.size", value: UInt64(data.count))
+        create.addParameter(field: "wired.attachment.sha256", value: digest)
+
+        guard let createResponse = try await send(create) else {
+            throw WiredError(withTitle: "Attachment", message: "No response from server while creating attachment.")
+        }
+
+        if createResponse.name == "wired.error" {
+            throw WiredError(message: createResponse)
+        }
+
+        guard createResponse.name == "wired.attachment.created",
+              let attachmentID = createResponse.uuid(forField: "wired.attachment.id") else {
+            throw WiredError(withTitle: "Attachment", message: "Invalid attachment creation response from server.")
+        }
+
+        var offset = 0
+        let chunkSize = 256 * 1024
+
+        while offset < data.count {
+            let upperBound = min(offset + chunkSize, data.count)
+            let chunk = data.subdata(in: offset..<upperBound)
+
+            let upload = P7Message(withName: "wired.attachment.upload", spec: spec)
+            upload.addParameter(field: "wired.attachment.id", value: attachmentID)
+            upload.addParameter(field: "wired.attachment.offset", value: UInt64(offset))
+            upload.addParameter(field: "wired.attachment.data", value: chunk)
+
+            if let uploadResponse = try await send(upload), uploadResponse.name == "wired.error" {
+                throw WiredError(message: uploadResponse)
+            }
+
+            offset = upperBound
+        }
+
+        let complete = P7Message(withName: "wired.attachment.complete", spec: spec)
+        complete.addParameter(field: "wired.attachment.id", value: attachmentID)
+
+        guard let completeResponse = try await send(complete) else {
+            throw WiredError(withTitle: "Attachment", message: "No completion response from server.")
+        }
+
+        if completeResponse.name == "wired.error" {
+            throw WiredError(message: completeResponse)
+        }
+
+        guard completeResponse.name == "wired.attachment.completed" else {
+            throw WiredError(withTitle: "Attachment", message: "Invalid attachment completion response from server.")
+        }
+
+        return attachmentID
+    }
+
+    private func uploadPrivateMessageAttachment(_ attachment: ChatDraftAttachment, toUserID userID: UInt32) async throws -> String {
+        let data = try Data(contentsOf: attachment.fileURL)
+        let digest = SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
+
+        let create = P7Message(withName: "wired.attachment.create", spec: spec)
+        create.addParameter(field: "wired.user.id", value: userID)
+        create.addParameter(field: "wired.attachment.name", value: attachment.fileName)
+        create.addParameter(field: "wired.attachment.media_type", value: attachment.mediaType)
+        create.addParameter(field: "wired.attachment.size", value: UInt64(data.count))
+        create.addParameter(field: "wired.attachment.sha256", value: digest)
+
+        guard let createResponse = try await send(create) else {
+            throw WiredError(withTitle: "Attachment", message: "No response from server while creating attachment.")
+        }
+
+        if createResponse.name == "wired.error" {
+            throw WiredError(message: createResponse)
+        }
+
+        guard createResponse.name == "wired.attachment.created",
+              let attachmentID = createResponse.uuid(forField: "wired.attachment.id") else {
+            throw WiredError(withTitle: "Attachment", message: "Invalid attachment creation response from server.")
+        }
+
+        var offset = 0
+        let chunkSize = 256 * 1024
+
+        while offset < data.count {
+            let upperBound = min(offset + chunkSize, data.count)
+            let chunk = data.subdata(in: offset..<upperBound)
+
+            let upload = P7Message(withName: "wired.attachment.upload", spec: spec)
+            upload.addParameter(field: "wired.attachment.id", value: attachmentID)
+            upload.addParameter(field: "wired.attachment.offset", value: UInt64(offset))
+            upload.addParameter(field: "wired.attachment.data", value: chunk)
+
+            if let uploadResponse = try await send(upload), uploadResponse.name == "wired.error" {
+                throw WiredError(message: uploadResponse)
+            }
+
+            offset = upperBound
+        }
+
+        let complete = P7Message(withName: "wired.attachment.complete", spec: spec)
+        complete.addParameter(field: "wired.attachment.id", value: attachmentID)
+
+        guard let completeResponse = try await send(complete) else {
+            throw WiredError(withTitle: "Attachment", message: "No completion response from server.")
+        }
+
+        if completeResponse.name == "wired.error" {
+            throw WiredError(message: completeResponse)
+        }
+
+        guard completeResponse.name == "wired.attachment.completed" else {
+            throw WiredError(withTitle: "Attachment", message: "Invalid attachment completion response from server.")
+        }
+
+        return attachmentID
     }
 
     @MainActor

--- a/Wired 3/Features/Boards/Views/EditPostView.swift
+++ b/Wired 3/Features/Boards/Views/EditPostView.swift
@@ -16,16 +16,25 @@ public struct EditPostView: View {
     let thread: BoardThread?
 
     @State private var text: String
+    @State private var attachments: [ComposerAttachmentItem]
     @State private var isSubmitting = false
+
+    private let initialAttachmentReferenceKeys: [String]
 
     init(post: BoardPost, thread: BoardThread?) {
         self.post = post
         self.thread = thread
         self._text = State(initialValue: post.text)
+        self._attachments = State(initialValue: post.attachments.map(ComposerAttachmentItem.remote))
+        self.initialAttachmentReferenceKeys = post.attachments.map { "remote:\($0.id.lowercased())" }
     }
 
     private var canSubmit: Bool {
         !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty && !isSubmitting
+    }
+
+    private var attachmentReferencesChanged: Bool {
+        attachments.map(Self.attachmentReferenceKey(for:)) != initialAttachmentReferenceKeys
     }
 
     public var body: some View {
@@ -42,7 +51,13 @@ public struct EditPostView: View {
             Divider()
 
             // Composer — edge-to-edge
-            MarkdownComposer(text: $text, autoFocus: true, onOptionEnter: save)
+            MarkdownComposer(
+                text: $text,
+                attachments: $attachments,
+                autoFocus: true,
+                onOptionEnter: save,
+                onAttachmentError: { runtime.lastError = $0 }
+            )
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
 
             Divider()
@@ -71,7 +86,9 @@ public struct EditPostView: View {
                 try await runtime.editPost(
                     uuid: post.uuid,
                     subject: thread?.subject ?? "",
-                    text: text.trimmingCharacters(in: .whitespacesAndNewlines)
+                    text: text.trimmingCharacters(in: .whitespacesAndNewlines),
+                    attachments: attachments,
+                    sendAttachmentIDs: attachmentReferencesChanged
                 )
                 if let thread {
                     try await runtime.getPosts(forThread: thread)
@@ -83,6 +100,15 @@ public struct EditPostView: View {
                     isSubmitting = false
                 }
             }
+        }
+    }
+
+    private static func attachmentReferenceKey(for attachment: ComposerAttachmentItem) -> String {
+        switch attachment {
+        case .local(let draft):
+            return "local:\(draft.id.uuidString.lowercased())"
+        case .remote(let descriptor):
+            return "remote:\(descriptor.id.lowercased())"
         }
     }
 }

--- a/Wired 3/Features/Boards/Views/EditThreadView.swift
+++ b/Wired 3/Features/Boards/Views/EditThreadView.swift
@@ -16,6 +16,8 @@ public struct EditThreadView: View {
 
     @State private var subject: String
     @State private var text: String = ""
+    @State private var attachments: [ComposerAttachmentItem] = []
+    @State private var initialAttachmentReferenceKeys: [String] = []
     @State private var isSubmitting = false
 
     init(thread: BoardThread) {
@@ -27,6 +29,10 @@ public struct EditThreadView: View {
         !subject.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
             && !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
             && !isSubmitting
+    }
+
+    private var attachmentReferencesChanged: Bool {
+        attachments.map(Self.attachmentReferenceKey(for:)) != initialAttachmentReferenceKeys
     }
 
     public var body: some View {
@@ -50,7 +56,12 @@ public struct EditThreadView: View {
             Divider()
 
             // Composer — edge-to-edge
-            MarkdownComposer(text: $text, onOptionEnter: save)
+            MarkdownComposer(
+                text: $text,
+                attachments: $attachments,
+                onOptionEnter: save,
+                onAttachmentError: { runtime.lastError = $0 }
+            )
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
 
             Divider()
@@ -73,9 +84,15 @@ public struct EditThreadView: View {
             // Prefill body with currently loaded first post when available.
             if let firstPost = thread.posts.first {
                 text = firstPost.text
+                let composerAttachments = firstPost.attachments.map(ComposerAttachmentItem.remote)
+                attachments = composerAttachments
+                initialAttachmentReferenceKeys = composerAttachments.map(Self.attachmentReferenceKey(for:))
             } else {
                 try? await runtime.getPosts(forThread: thread)
                 text = thread.posts.first?.text ?? ""
+                let composerAttachments = (thread.posts.first?.attachments ?? []).map(ComposerAttachmentItem.remote)
+                attachments = composerAttachments
+                initialAttachmentReferenceKeys = composerAttachments.map(Self.attachmentReferenceKey(for:))
             }
         }
     }
@@ -88,7 +105,9 @@ public struct EditThreadView: View {
                 try await runtime.editThread(
                     uuid: thread.uuid,
                     subject: subject.trimmingCharacters(in: .whitespacesAndNewlines),
-                    text: text.trimmingCharacters(in: .whitespacesAndNewlines)
+                    text: text.trimmingCharacters(in: .whitespacesAndNewlines),
+                    attachments: attachments,
+                    sendAttachmentIDs: attachmentReferencesChanged
                 )
                 try await runtime.getPosts(forThread: thread)
                 await MainActor.run { dismiss() }
@@ -98,6 +117,15 @@ public struct EditThreadView: View {
                     isSubmitting = false
                 }
             }
+        }
+    }
+
+    private static func attachmentReferenceKey(for attachment: ComposerAttachmentItem) -> String {
+        switch attachment {
+        case .local(let draft):
+            return "local:\(draft.id.uuidString.lowercased())"
+        case .remote(let descriptor):
+            return "remote:\(descriptor.id.lowercased())"
         }
     }
 }

--- a/Wired 3/Features/Boards/Views/MarkdownComposer.swift
+++ b/Wired 3/Features/Boards/Views/MarkdownComposer.swift
@@ -7,6 +7,7 @@
 //
 
 import SwiftUI
+import UniformTypeIdentifiers
 #if os(macOS)
 import AppKit
 #endif
@@ -129,13 +130,34 @@ struct ResizableSheet: NSViewRepresentable {
 
 struct MarkdownComposer: View {
     @Binding var text: String
+    @Binding var attachments: [ComposerAttachmentItem]
     var minHeight: CGFloat = 180
     var autoFocus: Bool = false
     var bordered: Bool = false
     var onOptionEnter: (() -> Void)?
+    var onAttachmentError: ((Error) -> Void)?
 
     @State private var selectedRange: NSRange = NSRange(location: 0, length: 0)
     @State private var showPreview = false
+    @State private var isAttachmentDropTargeted = false
+
+    init(
+        text: Binding<String>,
+        attachments: Binding<[ComposerAttachmentItem]> = .constant([]),
+        minHeight: CGFloat = 180,
+        autoFocus: Bool = false,
+        bordered: Bool = false,
+        onOptionEnter: (() -> Void)? = nil,
+        onAttachmentError: ((Error) -> Void)? = nil
+    ) {
+        self._text = text
+        self._attachments = attachments
+        self.minHeight = minHeight
+        self.autoFocus = autoFocus
+        self.bordered = bordered
+        self.onOptionEnter = onOptionEnter
+        self.onAttachmentError = onAttachmentError
+    }
 
     var body: some View {
         baseContent
@@ -147,6 +169,19 @@ struct MarkdownComposer: View {
                     }
                 }
             )
+            .overlay {
+                RoundedRectangle(cornerRadius: 10, style: .continuous)
+                    .stroke(Color.accentColor.opacity(isAttachmentDropTargeted ? 0.9 : 0), lineWidth: 4)
+                    .background(
+                        RoundedRectangle(cornerRadius: 10, style: .continuous)
+                            .fill(Color.accentColor.opacity(isAttachmentDropTargeted ? 0.08 : 0))
+                    )
+                    .padding(4)
+                    .allowsHitTesting(false)
+            }
+            .onDrop(of: [UTType.fileURL.identifier], isTargeted: $isAttachmentDropTargeted) { providers in
+                handleFileDrop(providers: providers)
+            }
     }
 
     @ViewBuilder
@@ -176,6 +211,7 @@ struct MarkdownComposer: View {
             Divider().frame(height: 14).padding(.horizontal, 3)
             toolbarButton(icon: "link", help: "Lien") { insertLink() }
             toolbarButton(icon: "photo", help: "Image") { insertImage() }
+            toolbarButton(icon: "paperclip", help: "Attach file") { chooseFiles() }
             Divider().frame(height: 14).padding(.horizontal, 3)
             toolbarButton(icon: "text.quote", help: "Citation") { prefixLines(with: "> ") }
             toolbarButton(icon: "list.bullet", help: "Liste") { prefixLines(with: "- ") }
@@ -219,13 +255,31 @@ struct MarkdownComposer: View {
     }
 
     private var editorPane: some View {
-        MarkdownTextView(
-            text: $text,
-            selectedRange: $selectedRange,
-            autoFocus: autoFocus,
-            onOptionEnter: onOptionEnter
-        )
-        .frame(minHeight: minHeight, maxHeight: .infinity)
+        VStack(alignment: .leading, spacing: 0) {
+            if !attachments.isEmpty {
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: 8) {
+                        ForEach(attachments) { attachment in
+                            ComposerAttachmentChipView(attachment: attachment) {
+                                removeAttachment(attachment)
+                            }
+                        }
+                    }
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 8)
+                }
+
+                Divider()
+            }
+
+            MarkdownTextView(
+                text: $text,
+                selectedRange: $selectedRange,
+                autoFocus: autoFocus,
+                onOptionEnter: onOptionEnter
+            )
+            .frame(minHeight: minHeight, maxHeight: .infinity)
+        }
     }
 
     private func toolbarButton(icon: String, help: String, action: @escaping () -> Void) -> some View {
@@ -295,6 +349,136 @@ struct MarkdownComposer: View {
 
         text = ns.replacingCharacters(in: lineRange, with: transformed)
         selectedRange = NSRange(location: lineRange.location, length: (transformed as NSString).length)
+    }
+
+    private func insertAttachmentReferences(_ references: [String]) {
+        guard !references.isEmpty else { return }
+        let replacement = references.joined(separator: "\n")
+        let ns = text as NSString
+        let range = clampedRange(in: text)
+        text = ns.replacingCharacters(in: range, with: replacement)
+        let caret = range.location + (replacement as NSString).length
+        selectedRange = NSRange(location: caret, length: 0)
+    }
+
+    private func removeAttachment(_ attachment: ComposerAttachmentItem) {
+        attachments.removeAll { $0.id == attachment.id }
+        text = text.replacingOccurrences(of: attachment.markdownReference, with: "")
+            .replacingOccurrences(of: attachment.referenceURLString, with: "")
+    }
+
+    private func chooseFiles() {
+        let panel = NSOpenPanel()
+        panel.allowsMultipleSelection = true
+        panel.canChooseDirectories = false
+        panel.canChooseFiles = true
+        panel.resolvesAliases = true
+
+        guard panel.runModal() == .OK else { return }
+        addFiles(panel.urls)
+    }
+
+    private func addFiles(_ urls: [URL]) {
+        do {
+            var updated = attachments
+            var insertedReferences: [String] = []
+
+            for url in urls {
+                let draft = try ChatDraftAttachment(fileURL: url)
+                let item = ComposerAttachmentItem.local(draft)
+                let alreadyPresent = updated.contains { existing in
+                    switch (existing, item) {
+                    case (.local(let lhs), .local(let rhs)):
+                        return lhs.fileURL == rhs.fileURL
+                    case (.remote(let lhs), .remote(let rhs)):
+                        return lhs.id == rhs.id
+                    default:
+                        return false
+                    }
+                }
+
+                guard !alreadyPresent else { continue }
+                updated.append(item)
+                insertedReferences.append(item.markdownReference)
+            }
+
+            try ComposerAttachmentItem.validateCollection(updated)
+            attachments = updated
+            insertAttachmentReferences(insertedReferences)
+        } catch {
+            onAttachmentError?(error)
+        }
+    }
+
+    private func handleFileDrop(providers: [NSItemProvider]) -> Bool {
+        let fileProviders = providers.filter {
+            $0.hasItemConformingToTypeIdentifier(UTType.fileURL.identifier)
+        }
+
+        guard !fileProviders.isEmpty else { return false }
+
+        for provider in fileProviders {
+            provider.loadDataRepresentation(forTypeIdentifier: UTType.fileURL.identifier) { data, error in
+                if let error {
+                    DispatchQueue.main.async {
+                        onAttachmentError?(error)
+                    }
+                    return
+                }
+
+                guard let data,
+                      let fileURL = URL(dataRepresentation: data, relativeTo: nil) else {
+                    return
+                }
+
+                DispatchQueue.main.async {
+                    addFiles([fileURL])
+                }
+            }
+        }
+
+        return true
+    }
+}
+
+private struct ComposerAttachmentChipView: View {
+    let attachment: ComposerAttachmentItem
+    let onRemove: () -> Void
+
+    private var iconName: String {
+        attachment.isImage ? "photo" : "doc"
+    }
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Image(systemName: iconName)
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(Color.accentColor)
+
+            (
+                Text(attachment.fileName)
+                    .font(.subheadline.weight(.medium))
+                +
+                Text("  \(attachment.fileSizeDescription)")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            )
+            .lineLimit(1)
+
+            Button(action: onRemove) {
+                Image(systemName: "xmark.circle.fill")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            .buttonStyle(.plain)
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 7)
+        .background(
+            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                .fill(Color.secondary.opacity(0.10))
+        )
+        .fixedSize(horizontal: true, vertical: false)
     }
 }
 
@@ -443,9 +627,27 @@ private final class FocusTextView: NSTextView {
 #else
 struct MarkdownComposer: View {
     @Binding var text: String
+    @Binding var attachments: [ComposerAttachmentItem]
     var minHeight: CGFloat = 180
     var autoFocus: Bool = false
     var onOptionEnter: (() -> Void)?
+    var onAttachmentError: ((Error) -> Void)?
+
+    init(
+        text: Binding<String>,
+        attachments: Binding<[ComposerAttachmentItem]> = .constant([]),
+        minHeight: CGFloat = 180,
+        autoFocus: Bool = false,
+        onOptionEnter: (() -> Void)? = nil,
+        onAttachmentError: ((Error) -> Void)? = nil
+    ) {
+        self._text = text
+        self._attachments = attachments
+        self.minHeight = minHeight
+        self.autoFocus = autoFocus
+        self.onOptionEnter = onOptionEnter
+        self.onAttachmentError = onAttachmentError
+    }
 
     var body: some View {
         VStack(spacing: 8) {
@@ -455,6 +657,7 @@ struct MarkdownComposer: View {
                 button("Code", help: "Code inline") { append("`code`") }
                 button("Link", help: "Lien") { append("[label](https://)") }
                 button("Img", help: "Image") { append("![alt](https://)") }
+                button("Attach", help: "Attachment") {}
                 button("Quote", help: "Citation") { append("\n> ") }
                 button("List", help: "Liste") { append("\n- ") }
                 Spacer(minLength: 0)

--- a/Wired 3/Features/Boards/Views/NewThreadView.swift
+++ b/Wired 3/Features/Boards/Views/NewThreadView.swift
@@ -20,6 +20,7 @@ struct NewThreadView: View {
 
     @State private var subject: String = ""
     @State private var text: String    = ""
+    @State private var attachments: [ComposerAttachmentItem] = []
     @State private var isPosting       = false
     @FocusState private var focusedField: NewThreadField?
 
@@ -56,7 +57,13 @@ struct NewThreadView: View {
             Divider()
 
             // Composer — edge-to-edge
-            MarkdownComposer(text: $text, autoFocus: false, onOptionEnter: post)
+            MarkdownComposer(
+                text: $text,
+                attachments: $attachments,
+                autoFocus: false,
+                onOptionEnter: post,
+                onAttachmentError: { runtime.lastError = $0 }
+            )
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
 
             Divider()
@@ -85,7 +92,8 @@ struct NewThreadView: View {
         Task {
             try? await runtime.addThread(toBoard: board,
                                          subject: subject.trimmingCharacters(in: .whitespaces),
-                                         text: text.trimmingCharacters(in: .whitespaces))
+                                         text: text.trimmingCharacters(in: .whitespaces),
+                                         attachments: attachments)
             await MainActor.run { dismiss() }
         }
     }

--- a/Wired 3/Features/Boards/Views/PostRowView.swift
+++ b/Wired 3/Features/Boards/Views/PostRowView.swift
@@ -8,6 +8,33 @@
 
 import SwiftUI
 
+private struct PostRowTextSegment: Identifiable {
+    enum Kind {
+        case body
+        case quote
+    }
+
+    let id: String
+    let kind: Kind
+    let text: String
+}
+
+private struct PostRowQuoteLine: Identifiable {
+    let id: String
+    let level: Int
+    let text: String
+}
+
+private struct PostRowContentBlock: Identifiable {
+    enum Kind {
+        case text(String)
+        case attachment(ChatAttachmentDescriptor)
+    }
+
+    let id: String
+    let kind: Kind
+}
+
 struct PostRowView: View {
     let post: BoardPost
     let highlightQuery: String?
@@ -25,33 +52,6 @@ struct PostRowView: View {
     var onSelectImage: ((ChatImageQuickLookSource) -> Void)?
     var onOpenQuickLook: ((ChatImageQuickLookSource) -> Void)?
     @State private var isHoveringText = false
-
-    private struct TextSegment: Identifiable {
-        enum Kind {
-            case body
-            case quote
-        }
-
-        let id: String
-        let kind: Kind
-        let text: String
-    }
-
-    private struct QuoteLine: Identifiable {
-        let id: String
-        let level: Int
-        let text: String
-    }
-
-    private struct ContentBlock: Identifiable {
-        enum Kind {
-            case text(String)
-            case attachment(ChatAttachmentDescriptor)
-        }
-
-        let id: String
-        let kind: Kind
-    }
 
     private static let dateFormatter: DateFormatter = {
         let formatter = DateFormatter()
@@ -76,22 +76,22 @@ struct PostRowView: View {
         )
     }
 
-    private func segments(for text: String) -> [TextSegment] {
-        var result: [TextSegment] = []
+    private func segments(for text: String) -> [PostRowTextSegment] {
+        var result: [PostRowTextSegment] = []
         var currentBody: [String] = []
         var currentQuote: [String] = []
         var nextSegmentIndex = 0
 
         func flushBody() {
             guard !currentBody.isEmpty else { return }
-            result.append(TextSegment(id: "segment-\(nextSegmentIndex)", kind: .body, text: currentBody.joined(separator: "\n")))
+            result.append(PostRowTextSegment(id: "segment-\(nextSegmentIndex)", kind: .body, text: currentBody.joined(separator: "\n")))
             nextSegmentIndex += 1
             currentBody.removeAll()
         }
 
         func flushQuote() {
             guard !currentQuote.isEmpty else { return }
-            result.append(TextSegment(id: "segment-\(nextSegmentIndex)", kind: .quote, text: currentQuote.joined(separator: "\n")))
+            result.append(PostRowTextSegment(id: "segment-\(nextSegmentIndex)", kind: .quote, text: currentQuote.joined(separator: "\n")))
             nextSegmentIndex += 1
             currentQuote.removeAll()
         }
@@ -112,21 +112,21 @@ struct PostRowView: View {
         return result
     }
 
-    private var contentBlocks: [ContentBlock] {
+    private var contentBlocks: [PostRowContentBlock] {
         let attachmentsByID = Dictionary(uniqueKeysWithValues: post.attachments.map { ($0.id.lowercased(), $0) })
         let pattern = #"\[([^\]]+)\]\(attachment://(?:draft/)?([0-9a-fA-F\-]+)\)"#
 
         guard let regex = try? NSRegularExpression(pattern: pattern) else {
-            return [ContentBlock(id: "text-0", kind: .text(post.text))]
+            return [PostRowContentBlock(id: "text-0", kind: .text(post.text))]
         }
 
         let nsText = post.text as NSString
         let matches = regex.matches(in: post.text, options: [], range: NSRange(location: 0, length: nsText.length))
         guard !matches.isEmpty else {
-            return [ContentBlock(id: "text-0", kind: .text(post.text))]
+            return [PostRowContentBlock(id: "text-0", kind: .text(post.text))]
         }
 
-        var blocks: [ContentBlock] = []
+        var blocks: [PostRowContentBlock] = []
         var renderedAttachmentIDs = Set<String>()
         var cursor = 0
 
@@ -137,14 +137,14 @@ struct PostRowView: View {
             if fullRange.location > cursor {
                 let text = nsText.substring(with: NSRange(location: cursor, length: fullRange.location - cursor))
                 if !text.isEmpty {
-                    blocks.append(ContentBlock(id: "text-\(blocks.count)", kind: .text(text)))
+                    blocks.append(PostRowContentBlock(id: "text-\(blocks.count)", kind: .text(text)))
                 }
             }
 
             if idRange.location != NSNotFound {
                 let attachmentID = nsText.substring(with: idRange).lowercased()
                 if let attachment = attachmentsByID[attachmentID] {
-                    blocks.append(ContentBlock(id: "attachment-\(attachmentID)-\(blocks.count)", kind: .attachment(attachment)))
+                    blocks.append(PostRowContentBlock(id: "attachment-\(attachmentID)-\(blocks.count)", kind: .attachment(attachment)))
                     renderedAttachmentIDs.insert(attachmentID)
                 }
             }
@@ -155,12 +155,12 @@ struct PostRowView: View {
         if cursor < nsText.length {
             let trailingText = nsText.substring(from: cursor)
             if !trailingText.isEmpty {
-                blocks.append(ContentBlock(id: "text-\(blocks.count)", kind: .text(trailingText)))
+                blocks.append(PostRowContentBlock(id: "text-\(blocks.count)", kind: .text(trailingText)))
             }
         }
 
         for attachment in post.attachments where !renderedAttachmentIDs.contains(attachment.id.lowercased()) {
-            blocks.append(ContentBlock(id: "attachment-\(attachment.id.lowercased())-\(blocks.count)", kind: .attachment(attachment)))
+            blocks.append(PostRowContentBlock(id: "attachment-\(attachment.id.lowercased())-\(blocks.count)", kind: .attachment(attachment)))
         }
 
         return blocks
@@ -170,13 +170,13 @@ struct PostRowView: View {
         post.text.detectedHTTPImageURLs()
     }
 
-    private func quoteLines(from text: String) -> [QuoteLine] {
+    private func quoteLines(from text: String) -> [PostRowQuoteLine] {
         text.components(separatedBy: .newlines).enumerated().compactMap { index, rawLine in
             parseQuoteLine(rawLine, index: index)
         }
     }
 
-    private func parseQuoteLine(_ rawLine: String, index: Int) -> QuoteLine? {
+    private func parseQuoteLine(_ rawLine: String, index: Int) -> PostRowQuoteLine? {
         let chars = Array(rawLine)
         var i = 0
         while i < chars.count, chars[i].isWhitespace { i += 1 }
@@ -192,7 +192,7 @@ struct PostRowView: View {
         guard level > 0 else { return nil }
 
         let content = i < chars.count ? String(chars[i...]).trimmingCharacters(in: .whitespaces) : ""
-        return QuoteLine(id: "quote-\(index)", level: level, text: content.isEmpty ? " " : content)
+        return PostRowQuoteLine(id: "quote-\(index)", level: level, text: content.isEmpty ? " " : content)
     }
 
     @ViewBuilder

--- a/Wired 3/Features/Boards/Views/PostRowView.swift
+++ b/Wired 3/Features/Boards/Views/PostRowView.swift
@@ -11,15 +11,19 @@ import SwiftUI
 struct PostRowView: View {
     let post: BoardPost
     let highlightQuery: String?
+    let availableContentWidth: CGFloat
     let canReply: Bool
     let canEdit: Bool
     let canDelete: Bool
     let canReact: Bool
+    var selectedImageSource: ChatImageQuickLookSource?
     let onReply: () -> Void
     let onQuote: (String?) -> Void
     let onEdit: () -> Void
     let onDelete: () -> Void
     let onToggleReaction: (String) -> Void
+    var onSelectImage: ((ChatImageQuickLookSource) -> Void)?
+    var onOpenQuickLook: ((ChatImageQuickLookSource) -> Void)?
     @State private var isHoveringText = false
 
     private struct TextSegment: Identifiable {
@@ -28,15 +32,25 @@ struct PostRowView: View {
             case quote
         }
 
-        let id = UUID()
+        let id: String
         let kind: Kind
         let text: String
     }
 
     private struct QuoteLine: Identifiable {
-        let id = UUID()
+        let id: String
         let level: Int
         let text: String
+    }
+
+    private struct ContentBlock: Identifiable {
+        enum Kind {
+            case text(String)
+            case attachment(ChatAttachmentDescriptor)
+        }
+
+        let id: String
+        let kind: Kind
     }
 
     private static let dateFormatter: DateFormatter = {
@@ -45,43 +59,44 @@ struct PostRowView: View {
         formatter.timeStyle = .short
         return formatter
     }()
+    private let boardImageMaxHeight: CGFloat = 900
 
     static func dateString(_ value: Date) -> String {
         dateFormatter.string(from: value)
     }
 
-    private var renderedText: AttributedString {
-        post.text.attributedWithMarkdownAndDetectedLinks(
-            linkColor: .blue,
-            highlightQuery: highlightQuery
-        )
+    private var boardImageMaxWidth: CGFloat {
+        max(280, availableContentWidth - 4)
     }
 
     private func renderedText(for text: String) -> AttributedString {
-        text.attributedWithMarkdownAndDetectedLinks(
+        text.renderingBoardAttachmentReferences().attributedWithMarkdownAndDetectedLinks(
             linkColor: .blue,
             highlightQuery: highlightQuery
         )
     }
 
-    private var segments: [TextSegment] {
+    private func segments(for text: String) -> [TextSegment] {
         var result: [TextSegment] = []
         var currentBody: [String] = []
         var currentQuote: [String] = []
+        var nextSegmentIndex = 0
 
         func flushBody() {
             guard !currentBody.isEmpty else { return }
-            result.append(TextSegment(kind: .body, text: currentBody.joined(separator: "\n")))
+            result.append(TextSegment(id: "segment-\(nextSegmentIndex)", kind: .body, text: currentBody.joined(separator: "\n")))
+            nextSegmentIndex += 1
             currentBody.removeAll()
         }
 
         func flushQuote() {
             guard !currentQuote.isEmpty else { return }
-            result.append(TextSegment(kind: .quote, text: currentQuote.joined(separator: "\n")))
+            result.append(TextSegment(id: "segment-\(nextSegmentIndex)", kind: .quote, text: currentQuote.joined(separator: "\n")))
+            nextSegmentIndex += 1
             currentQuote.removeAll()
         }
 
-        for rawLine in post.text.components(separatedBy: .newlines) {
+        for rawLine in text.components(separatedBy: .newlines) {
             let trimmed = rawLine.trimmingCharacters(in: .whitespaces)
             if trimmed.hasPrefix(">") {
                 flushBody()
@@ -97,17 +112,71 @@ struct PostRowView: View {
         return result
     }
 
+    private var contentBlocks: [ContentBlock] {
+        let attachmentsByID = Dictionary(uniqueKeysWithValues: post.attachments.map { ($0.id.lowercased(), $0) })
+        let pattern = #"\[([^\]]+)\]\(attachment://(?:draft/)?([0-9a-fA-F\-]+)\)"#
+
+        guard let regex = try? NSRegularExpression(pattern: pattern) else {
+            return [ContentBlock(id: "text-0", kind: .text(post.text))]
+        }
+
+        let nsText = post.text as NSString
+        let matches = regex.matches(in: post.text, options: [], range: NSRange(location: 0, length: nsText.length))
+        guard !matches.isEmpty else {
+            return [ContentBlock(id: "text-0", kind: .text(post.text))]
+        }
+
+        var blocks: [ContentBlock] = []
+        var renderedAttachmentIDs = Set<String>()
+        var cursor = 0
+
+        for match in matches {
+            let fullRange = match.range(at: 0)
+            let idRange = match.range(at: 2)
+
+            if fullRange.location > cursor {
+                let text = nsText.substring(with: NSRange(location: cursor, length: fullRange.location - cursor))
+                if !text.isEmpty {
+                    blocks.append(ContentBlock(id: "text-\(blocks.count)", kind: .text(text)))
+                }
+            }
+
+            if idRange.location != NSNotFound {
+                let attachmentID = nsText.substring(with: idRange).lowercased()
+                if let attachment = attachmentsByID[attachmentID] {
+                    blocks.append(ContentBlock(id: "attachment-\(attachmentID)-\(blocks.count)", kind: .attachment(attachment)))
+                    renderedAttachmentIDs.insert(attachmentID)
+                }
+            }
+
+            cursor = fullRange.location + fullRange.length
+        }
+
+        if cursor < nsText.length {
+            let trailingText = nsText.substring(from: cursor)
+            if !trailingText.isEmpty {
+                blocks.append(ContentBlock(id: "text-\(blocks.count)", kind: .text(trailingText)))
+            }
+        }
+
+        for attachment in post.attachments where !renderedAttachmentIDs.contains(attachment.id.lowercased()) {
+            blocks.append(ContentBlock(id: "attachment-\(attachment.id.lowercased())-\(blocks.count)", kind: .attachment(attachment)))
+        }
+
+        return blocks
+    }
+
     private var imageURLs: [URL] {
         post.text.detectedHTTPImageURLs()
     }
 
     private func quoteLines(from text: String) -> [QuoteLine] {
-        text.components(separatedBy: .newlines).compactMap { rawLine in
-            parseQuoteLine(rawLine)
+        text.components(separatedBy: .newlines).enumerated().compactMap { index, rawLine in
+            parseQuoteLine(rawLine, index: index)
         }
     }
 
-    private func parseQuoteLine(_ rawLine: String) -> QuoteLine? {
+    private func parseQuoteLine(_ rawLine: String, index: Int) -> QuoteLine? {
         let chars = Array(rawLine)
         var i = 0
         while i < chars.count, chars[i].isWhitespace { i += 1 }
@@ -123,7 +192,7 @@ struct PostRowView: View {
         guard level > 0 else { return nil }
 
         let content = i < chars.count ? String(chars[i...]).trimmingCharacters(in: .whitespaces) : ""
-        return QuoteLine(level: level, text: content.isEmpty ? " " : content)
+        return QuoteLine(id: "quote-\(index)", level: level, text: content.isEmpty ? " " : content)
     }
 
     @ViewBuilder
@@ -177,36 +246,65 @@ struct PostRowView: View {
 
             // Post body
             VStack(alignment: .leading, spacing: 8) {
-                ForEach(segments) { segment in
-                    switch segment.kind {
-                    case .body:
-                        Text(renderedText(for: segment.text))
-                            .font(.body)
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                    case .quote:
-                        VStack(alignment: .leading, spacing: 4) {
-                            ForEach(quoteLines(from: segment.text)) { line in
-                                HStack(alignment: .firstTextBaseline, spacing: 7) {
-                                    HStack(spacing: 4) {
-                                        ForEach(0..<max(1, line.level), id: \.self) { _ in
-                                            RoundedRectangle(cornerRadius: 1)
-                                                .fill(Color.secondary.opacity(0.33))
-                                                .frame(width: 2, height: 15)
+                ForEach(contentBlocks) { block in
+                    switch block.kind {
+                    case .text(let text):
+                        ForEach(segments(for: text)) { segment in
+                            switch segment.kind {
+                            case .body:
+                                Text(renderedText(for: segment.text))
+                                    .font(.body)
+                                    .frame(maxWidth: .infinity, alignment: .leading)
+                            case .quote:
+                                VStack(alignment: .leading, spacing: 4) {
+                                    ForEach(quoteLines(from: segment.text)) { line in
+                                        HStack(alignment: .firstTextBaseline, spacing: 7) {
+                                            HStack(spacing: 4) {
+                                                ForEach(0..<max(1, line.level), id: \.self) { _ in
+                                                    RoundedRectangle(cornerRadius: 1)
+                                                        .fill(Color.secondary.opacity(0.33))
+                                                        .frame(width: 2, height: 15)
+                                                }
+                                            }
+                                            Text(renderedText(for: line.text))
+                                                .font(.body)
+                                                .foregroundStyle(.secondary)
+                                                .frame(maxWidth: .infinity, alignment: .leading)
                                         }
                                     }
-                                    Text(renderedText(for: line.text))
-                                        .font(.body)
-                                        .foregroundStyle(.secondary)
-                                        .frame(maxWidth: .infinity, alignment: .leading)
                                 }
+                                .padding(.vertical, 8)
+                                .padding(.horizontal, 10)
+                                .background(
+                                    RoundedRectangle(cornerRadius: 8)
+                                        .fill(Color.secondary.opacity(0.08))
+                                )
                             }
                         }
-                        .padding(.vertical, 8)
-                        .padding(.horizontal, 10)
-                        .background(
-                            RoundedRectangle(cornerRadius: 8)
-                                .fill(Color.secondary.opacity(0.08))
-                        )
+                    case .attachment(let attachment):
+                        if attachment.isImage {
+                            let source = ChatImageQuickLookSource.attachment(attachment)
+                            ChatAttachmentImageBubbleView(
+                                attachment: attachment,
+                                isFromYou: post.isOwn,
+                                showsTail: false,
+                                maxBubbleWidth: boardImageMaxWidth,
+                                maxBubbleHeight: boardImageMaxHeight,
+                                isSelected: selectedImageSource?.selectionID == source.selectionID,
+                                onSelect: {
+                                    onSelectImage?(source)
+                                },
+                                onOpenQuickLook: {
+                                    onOpenQuickLook?(source)
+                                }
+                            )
+                        } else {
+                            ChatAttachmentFileBubbleView(
+                                attachment: attachment,
+                                isFromYou: post.isOwn,
+                                showsTail: false
+                            )
+                        }
                     }
                 }
             }
@@ -217,28 +315,21 @@ struct PostRowView: View {
             if !imageURLs.isEmpty {
                 VStack(alignment: .leading, spacing: 8) {
                     ForEach(Array(imageURLs.prefix(3)), id: \.absoluteString) { url in
-                        Link(destination: url) {
-                            AsyncImage(url: url) { phase in
-                                switch phase {
-                                case .empty:
-                                    ProgressView()
-                                        .frame(maxWidth: .infinity, minHeight: 120)
-                                case .success(let image):
-                                    image
-                                        .resizable()
-                                        .scaledToFit()
-                                        .frame(maxWidth: 420)
-                                        .clipShape(RoundedRectangle(cornerRadius: 8))
-                                case .failure:
-                                    Label(url.lastPathComponent, systemImage: "exclamationmark.triangle")
-                                        .font(.caption)
-                                        .foregroundStyle(.secondary)
-                                @unknown default:
-                                    EmptyView()
-                                }
+                        let source = ChatImageQuickLookSource.remote(url)
+                        ChatRemoteImageBubbleView(
+                            url: url,
+                            isFromYou: post.isOwn,
+                            showsTail: false,
+                            maxBubbleWidth: boardImageMaxWidth,
+                            maxBubbleHeight: boardImageMaxHeight,
+                            isSelected: selectedImageSource?.selectionID == source.selectionID,
+                            onSelect: {
+                                onSelectImage?(source)
+                            },
+                            onOpenQuickLook: {
+                                onOpenQuickLook?(source)
                             }
-                        }
-                        .buttonStyle(.plain)
+                        )
                         .pointerOnHover()
                     }
                 }
@@ -295,5 +386,14 @@ struct PostRowView: View {
         #else
         return nil
         #endif
+    }
+}
+
+private extension String {
+    func renderingBoardAttachmentReferences() -> String {
+        let pattern = #"\[([^\]]+)\]\(attachment://(?:draft/[0-9a-fA-F\-]+|[0-9a-fA-F\-]+)\)"#
+        guard let regex = try? NSRegularExpression(pattern: pattern) else { return self }
+        let range = NSRange(startIndex..<endIndex, in: self)
+        return regex.stringByReplacingMatches(in: self, options: [], range: range, withTemplate: "$1")
     }
 }

--- a/Wired 3/Features/Boards/Views/PostsDetailView.swift
+++ b/Wired 3/Features/Boards/Views/PostsDetailView.swift
@@ -18,6 +18,10 @@ struct PostsDetailView: View {
     @State private var postToEdit: BoardPost?
     @State private var postToDelete: BoardPost?
     @State private var replyComposerContext: ReplyComposerContext?
+    @State private var selectedImageSource: ChatImageQuickLookSource?
+#if os(macOS)
+    @State private var quickLookController = ChatImageQuickLookController()
+#endif
 
     private struct ReplyComposerContext: Identifiable {
         let id = UUID()
@@ -157,43 +161,55 @@ struct PostsDetailView: View {
             Text(postToDelete?.text ?? "")
         }
         .background(Color.boardsTextBackground)
+        .onChange(of: threadUUID) {
+            selectedImageSource = nil
+        }
     }
 
     private func postsContainer(for thread: BoardThread) -> some View {
-        ScrollViewReader { proxy in
-            ScrollView {
-                LazyVStack(spacing: 0) {
-                    postsContent(for: thread)
-                    Color.clear
-                        .frame(height: 1)
-                        .id(bottomAnchorID)
+        GeometryReader { geometry in
+            let postContentWidth = max(280, geometry.size.width - 32)
+
+            ScrollViewReader { proxy in
+                ScrollView {
+                    LazyVStack(spacing: 0) {
+                        postsContent(for: thread, availableContentWidth: postContentWidth)
+                        Color.clear
+                            .frame(height: 1)
+                            .id(bottomAnchorID)
+                    }
                 }
-            }
-            .background(Color.boardsTextBackground)
-            .onAppear {
-                if thread.postsLoaded {
+                .background(Color.boardsTextBackground)
+#if os(macOS)
+                .chatQuickLookSpaceMonitor(isEnabled: selectedImageSource != nil) {
+                    openSelectedImageQuickLook()
+                }
+#endif
+                .onAppear {
+                    if thread.postsLoaded {
+                        if !scrollToPendingPostIfNeeded(proxy, animated: false) {
+                            scrollToBottom(proxy)
+                        }
+                    }
+                }
+                .onChange(of: thread.postsLoaded) { _, loaded in
+                    guard loaded else { return }
                     if !scrollToPendingPostIfNeeded(proxy, animated: false) {
                         scrollToBottom(proxy)
                     }
                 }
-            }
-            .onChange(of: thread.postsLoaded) { _, loaded in
-                guard loaded else { return }
-                if !scrollToPendingPostIfNeeded(proxy, animated: false) {
-                    scrollToBottom(proxy)
-                }
-            }
-            .onChange(of: thread.posts.count) { _, _ in
-                guard thread.postsLoaded else { return }
-                if !scrollToPendingPostIfNeeded(proxy) {
-                    scrollToBottom(proxy, animated: true)
+                .onChange(of: thread.posts.count) { _, _ in
+                    guard thread.postsLoaded else { return }
+                    if !scrollToPendingPostIfNeeded(proxy) {
+                        scrollToBottom(proxy, animated: true)
+                    }
                 }
             }
         }
     }
 
     @ViewBuilder
-    private func postsContent(for thread: BoardThread) -> some View {
+    private func postsContent(for thread: BoardThread, availableContentWidth: CGFloat) -> some View {
         if !thread.postsLoaded {
             ProgressView("Loading posts…")
                 .padding(40)
@@ -202,7 +218,7 @@ struct PostsDetailView: View {
                 .padding(40)
         } else {
             ForEach(sortedPosts(thread.posts)) { post in
-                postRow(post)
+                postRow(post, availableContentWidth: availableContentWidth)
             }
         }
     }
@@ -211,21 +227,30 @@ struct PostsDetailView: View {
         runtime.hasPrivilege("wired.account.board.add_reactions")
     }
 
-    private func postRow(_ post: BoardPost) -> some View {
+    private func postRow(_ post: BoardPost, availableContentWidth: CGFloat) -> some View {
         VStack(spacing: 0) {
             PostRowView(
                 post: post,
                 highlightQuery: highlightQuery,
+                availableContentWidth: availableContentWidth,
                 canReply: canReplyToThread,
                 canEdit: canEditPost(post),
                 canDelete: canDeletePost(post),
                 canReact: canReact,
+                selectedImageSource: selectedImageSource,
                 onReply: { openReplyFromPost(post, selectedText: nil) },
                 onQuote: { selectedText in openReplyFromPost(post, selectedText: selectedText) },
                 onEdit: { postToEdit = post },
                 onDelete: { postToDelete = post },
                 onToggleReaction: { emoji in
                     Task { try? await runtime.toggleReaction(emoji: emoji, forPost: post) }
+                },
+                onSelectImage: { source in
+                    selectedImageSource = source
+                },
+                onOpenQuickLook: { source in
+                    selectedImageSource = source
+                    openQuickLook(for: source)
                 }
             )
             .padding(.horizontal)
@@ -239,4 +264,26 @@ struct PostsDetailView: View {
                 .padding(.horizontal)
         }
     }
+
+#if os(macOS)
+    private func openSelectedImageQuickLook() {
+        guard let selectedImageSource else { return }
+        openQuickLook(for: selectedImageSource)
+    }
+
+    private func openQuickLook(for source: ChatImageQuickLookSource) {
+        Task {
+            do {
+                let url = try await source.quickLookURL(connectionID: runtime.id, runtime: runtime)
+                await MainActor.run {
+                    quickLookController.present(localURL: url, title: source.title)
+                }
+            } catch {
+                await MainActor.run {
+                    runtime.lastError = error
+                }
+            }
+        }
+    }
+#endif
 }

--- a/Wired 3/Features/Boards/Views/ReplyView.swift
+++ b/Wired 3/Features/Boards/Views/ReplyView.swift
@@ -23,6 +23,7 @@ struct ReplyView: View {
     let initialText: String?
 
     @State private var text: String  = ""
+    @State private var attachments: [ComposerAttachmentItem] = []
     @State private var isPosting     = false
 
     private static let dateFormatter: DateFormatter = {
@@ -103,7 +104,13 @@ struct ReplyView: View {
             Divider()
 
             // Composer — edge-to-edge
-            MarkdownComposer(text: $text, autoFocus: true, onOptionEnter: reply)
+            MarkdownComposer(
+                text: $text,
+                attachments: $attachments,
+                autoFocus: true,
+                onOptionEnter: reply,
+                onAttachmentError: { runtime.lastError = $0 }
+            )
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
 
             Divider()
@@ -135,7 +142,8 @@ struct ReplyView: View {
         isPosting = true
         Task {
             try? await runtime.addPost(toThread: thread,
-                                       text: text.trimmingCharacters(in: .whitespaces))
+                                       text: text.trimmingCharacters(in: .whitespaces),
+                                       attachments: attachments)
             await MainActor.run { dismiss() }
         }
     }

--- a/Wired 3/Features/Chats/Views/ChatAttachmentViews.swift
+++ b/Wired 3/Features/Chats/Views/ChatAttachmentViews.swift
@@ -256,15 +256,13 @@ struct ChatAttachmentImageBubbleView: View {
     let attachment: ChatAttachmentDescriptor
     let isFromYou: Bool
     let showsTail: Bool
+    var maxBubbleWidth: CGFloat = 280
+    var maxBubbleHeight: CGFloat = 360
     var isSelected: Bool = false
     var onSelect: (() -> Void)?
     var onOpenQuickLook: (() -> Void)?
 
     @State private var phase: Phase = .idle
-
-    private let maxBubbleWidth: CGFloat = 280
-    private let maxBubbleHeight: CGFloat = 360
-    private let placeholderSize = CGSize(width: 280, height: 190)
 
     enum Phase {
         case idle
@@ -291,6 +289,10 @@ struct ChatAttachmentImageBubbleView: View {
             return resolvedSize(for: image)
         }
         return placeholderSize
+    }
+
+    private var placeholderSize: CGSize {
+        CGSize(width: maxBubbleWidth, height: min(maxBubbleHeight, maxBubbleWidth * 0.68))
     }
 
     var body: some View {

--- a/Wired 3/Features/Chats/Views/ChatAttachmentViews.swift
+++ b/Wired 3/Features/Chats/Views/ChatAttachmentViews.swift
@@ -1,0 +1,311 @@
+//
+//  ChatAttachmentViews.swift
+//  Wired 3
+//
+
+import SwiftUI
+import UniformTypeIdentifiers
+#if os(macOS)
+import AppKit
+#endif
+
+struct ChatDraftAttachmentChipView: View {
+    let attachment: ChatDraftAttachment
+    let onRemove: () -> Void
+
+    private var iconName: String {
+        attachment.isImage ? "photo" : "doc"
+    }
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Image(systemName: iconName)
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(Color.accentColor)
+
+            (
+                Text(attachment.fileName)
+                    .font(.subheadline.weight(.medium))
+                +
+                Text("  \(attachment.fileSizeDescription)")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            )
+            .lineLimit(1)
+
+            Button {
+                onRemove()
+            } label: {
+                Image(systemName: "xmark.circle.fill")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            .buttonStyle(.plain)
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 7)
+        .background(
+            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                .fill(Color.secondary.opacity(0.10))
+        )
+        .fixedSize(horizontal: true, vertical: false)
+    }
+}
+
+struct ChatAttachmentImageBubbleView: View {
+    @Environment(ConnectionRuntime.self) private var runtime
+
+    let attachment: ChatAttachmentDescriptor
+    let isFromYou: Bool
+    let showsTail: Bool
+
+    @State private var phase: Phase = .idle
+
+    private let maxBubbleWidth: CGFloat = 280
+    private let maxBubbleHeight: CGFloat = 360
+    private let placeholderSize = CGSize(width: 280, height: 190)
+
+    enum Phase {
+        case idle
+        case loading
+        case success(PlatformImage)
+        case failure
+    }
+
+    private func resolvedSize(for image: PlatformImage) -> CGSize {
+        let natural = image.size
+        guard natural.width > 0, natural.height > 0 else { return placeholderSize }
+        let ratio = natural.height / natural.width
+        var width = min(natural.width, maxBubbleWidth)
+        var height = width * ratio
+        if height > maxBubbleHeight {
+            height = maxBubbleHeight
+            width = height / ratio
+        }
+        return CGSize(width: ceil(width), height: ceil(height))
+    }
+
+    private var currentSize: CGSize {
+        if case .success(let image) = phase {
+            return resolvedSize(for: image)
+        }
+        return placeholderSize
+    }
+
+    var body: some View {
+        bubbleContent
+            .frame(width: currentSize.width, height: currentSize.height)
+            .mask(bubbleMask)
+            .shadow(color: .black.opacity(0.06), radius: 1.5, y: 1)
+            .contextMenu {
+#if os(macOS)
+                Button {
+                    downloadAttachment()
+                } label: {
+                    Label("Download Image", systemImage: "square.and.arrow.down")
+                }
+#endif
+            }
+            .task(id: attachment.id) {
+                await load()
+            }
+    }
+
+    private var bubbleContent: some View {
+        ZStack {
+            LinearGradient(
+                colors: [
+                    Color.secondary.opacity(0.18),
+                    Color.secondary.opacity(0.12)
+                ],
+                startPoint: .topLeading,
+                endPoint: .bottomTrailing
+            )
+
+            switch phase {
+            case .idle, .loading:
+                ProgressView()
+                    .controlSize(.regular)
+                    .padding(.horizontal, 16)
+                    .padding(.vertical, 12)
+                    .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+            case .success(let image):
+                imageView(image)
+            case .failure:
+                VStack(spacing: 8) {
+                    Image(systemName: "photo.badge.exclamationmark")
+                        .font(.title3)
+                    Text(attachment.name)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .multilineTextAlignment(.center)
+                        .padding(.horizontal, 12)
+                }
+            }
+        }
+    }
+
+    private var bubbleMask: some View {
+        MessageBubble(showsTail: showsTail)
+            .fill(Color.white)
+            .rotation3DEffect(isFromYou ? .degrees(0) : .degrees(180), axis: (x: 0, y: 1, z: 0))
+    }
+
+    @ViewBuilder
+    private func imageView(_ image: PlatformImage) -> some View {
+        let size = resolvedSize(for: image)
+        Group {
+#if os(iOS)
+            Image(uiImage: image)
+                .resizable()
+                .scaledToFit()
+#else
+            Image(nsImage: image)
+                .resizable()
+                .scaledToFit()
+#endif
+        }
+        .frame(width: size.width, height: size.height)
+    }
+
+    @MainActor
+    private func load() async {
+        guard case .idle = phase else { return }
+        phase = .loading
+
+        do {
+            let data = try await runtime.imageData(for: attachment)
+            guard let image = AppImageCodec.platformImage(from: data) else {
+                phase = .failure
+                return
+            }
+            phase = .success(image)
+        } catch {
+            phase = .failure
+        }
+    }
+
+#if os(macOS)
+    @MainActor
+    private func downloadAttachment() {
+        Task {
+            do {
+                let data = try await runtime.downloadChatAttachmentData(attachment)
+                let panel = NSSavePanel()
+                panel.nameFieldStringValue = attachment.name
+                panel.canCreateDirectories = true
+                if panel.runModal() == .OK, let saveURL = panel.url {
+                    try data.write(to: saveURL, options: .atomic)
+                }
+            } catch {
+                runtime.lastError = error
+            }
+        }
+    }
+#endif
+}
+
+struct ChatAttachmentFileBubbleView: View {
+    @Environment(ConnectionRuntime.self) private var runtime
+
+    let attachment: ChatAttachmentDescriptor
+    let isFromYou: Bool
+    let showsTail: Bool
+
+    @State private var isSaving = false
+
+    private var iconName: String {
+        if attachment.isImage {
+            return "photo"
+        }
+
+        if attachment.mediaType.lowercased().hasPrefix("audio/") {
+            return "waveform"
+        }
+
+        if attachment.mediaType.lowercased().hasPrefix("video/") {
+            return "film"
+        }
+
+        if attachment.mediaType.lowercased().contains("pdf") {
+            return "doc.richtext"
+        }
+
+        return "doc"
+    }
+
+    var body: some View {
+        HStack {
+            if isFromYou { Spacer(minLength: 36) }
+
+            HStack(spacing: 12) {
+                Image(systemName: iconName)
+                    .font(.title3)
+                    .foregroundStyle(isFromYou ? .white : Color.accentColor)
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(attachment.name)
+                        .font(.subheadline.weight(.medium))
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                        .layoutPriority(1)
+                    Text(attachment.fileSizeDescription)
+                        .font(.caption)
+                        .foregroundStyle(isFromYou ? Color.white.opacity(0.8) : .secondary)
+                }
+
+#if os(macOS)
+                Button {
+                    saveAttachment()
+                } label: {
+                    if isSaving {
+                        ProgressView()
+                            .controlSize(.small)
+                    } else {
+                        Image(systemName: "square.and.arrow.down")
+                    }
+                }
+                .buttonStyle(.plain)
+                .foregroundStyle(isFromYou ? .white : Color.accentColor)
+#endif
+            }
+            .padding(.horizontal, 14)
+            .padding(.vertical, 12)
+            .background(
+                MessageBubble(showsTail: showsTail)
+                    .fill(isFromYou ? Color.accentColor : Color.gray.opacity(0.12))
+                    .rotation3DEffect(isFromYou ? .degrees(0) : .degrees(180), axis: (x: 0, y: 1, z: 0))
+            )
+            .foregroundStyle(isFromYou ? .white : .primary)
+            .frame(maxWidth: 320, alignment: isFromYou ? .trailing : .leading)
+
+            if !isFromYou { Spacer(minLength: 36) }
+        }
+    }
+
+#if os(macOS)
+    @MainActor
+    private func saveAttachment() {
+        guard !isSaving else { return }
+        isSaving = true
+
+        Task {
+            defer { Task { @MainActor in isSaving = false } }
+
+            do {
+                let data = try await runtime.downloadChatAttachmentData(attachment)
+                let panel = NSSavePanel()
+                panel.nameFieldStringValue = attachment.name
+                panel.canCreateDirectories = true
+                if panel.runModal() == .OK, let saveURL = panel.url {
+                    try data.write(to: saveURL, options: .atomic)
+                }
+            } catch {
+                await MainActor.run {
+                    runtime.lastError = error
+                }
+            }
+        }
+    }
+#endif
+}

--- a/Wired 3/Features/Chats/Views/ChatAttachmentViews.swift
+++ b/Wired 3/Features/Chats/Views/ChatAttachmentViews.swift
@@ -6,6 +6,9 @@
 import SwiftUI
 import UniformTypeIdentifiers
 #if os(macOS)
+import Quartz
+#endif
+#if os(macOS)
 import AppKit
 #endif
 
@@ -52,12 +55,210 @@ struct ChatDraftAttachmentChipView: View {
     }
 }
 
+enum ChatImageQuickLookSource: Hashable {
+    case attachment(ChatAttachmentDescriptor)
+    case remote(URL)
+
+    var selectionID: String {
+        switch self {
+        case .attachment(let attachment):
+            return "attachment:\(attachment.id)"
+        case .remote(let url):
+            return "remote:\(url.absoluteString)"
+        }
+    }
+
+    var title: String {
+        switch self {
+        case .attachment(let attachment):
+            return attachment.name
+        case .remote(let url):
+            let filename = url.lastPathComponent.trimmingCharacters(in: .whitespacesAndNewlines)
+            return filename.isEmpty ? "Image" : filename
+        }
+    }
+
+    var preferredFilenameExtension: String? {
+        switch self {
+        case .attachment(let attachment):
+            return attachment.preferredFilenameExtension
+        case .remote(let url):
+            let pathExtension = url.pathExtension.trimmingCharacters(in: .whitespacesAndNewlines)
+            return pathExtension.isEmpty ? nil : pathExtension
+        }
+    }
+
+#if os(macOS)
+    func cachedQuickLookURL(
+        connectionID: UUID,
+        baseDirectory: URL = FileManager.default.temporaryDirectory
+    ) -> URL {
+        let cacheDirectory = baseDirectory.appendingPathComponent("ChatQuickLook", isDirectory: true)
+        try? FileManager.default.createDirectory(at: cacheDirectory, withIntermediateDirectories: true)
+
+        let fileStem = title
+            .replacingOccurrences(of: "/", with: "-")
+            .replacingOccurrences(of: ":", with: "-")
+            .replacingOccurrences(of: "\\", with: "-")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .nilIfEmpty ?? "Preview"
+        let suffix = abs(selectionID.hashValue)
+        let fileExtension = preferredFilenameExtension ?? "bin"
+        return cacheDirectory.appendingPathComponent(
+            "\(fileStem)-\(connectionID.uuidString.lowercased())-\(suffix).\(fileExtension)",
+            isDirectory: false
+        )
+    }
+
+    func quickLookURL(connectionID: UUID, runtime: ConnectionRuntime) async throws -> URL {
+        let cacheURL = cachedQuickLookURL(connectionID: connectionID)
+        if FileManager.default.fileExists(atPath: cacheURL.path) {
+            return cacheURL
+        }
+
+        let data: Data
+        switch self {
+        case .attachment(let attachment):
+            data = try await runtime.downloadChatAttachmentData(attachment)
+        case .remote(let url):
+            if let cached = await ChatRemoteImageCache.shared.data(for: url) {
+                data = cached
+            } else {
+                let (remoteData, _) = try await URLSession.shared.data(from: url)
+                await ChatRemoteImageCache.shared.store(remoteData, for: url)
+                data = remoteData
+            }
+        }
+
+        try data.write(to: cacheURL, options: .atomic)
+        return cacheURL
+    }
+#endif
+}
+
+#if os(macOS)
+private final class ChatImageQuickLookPreviewItem: NSObject, QLPreviewItem {
+    let previewItemURL: URL?
+    let previewItemTitle: String?
+
+    init(url: URL, title: String) {
+        self.previewItemURL = url
+        self.previewItemTitle = title
+    }
+}
+
+final class ChatImageQuickLookController: NSObject, QLPreviewPanelDataSource, QLPreviewPanelDelegate {
+    private var previewItem: ChatImageQuickLookPreviewItem?
+    private var sourceFrame: NSRect = .zero
+
+    @MainActor
+    func present(localURL: URL, title: String, sourceFrame: NSRect = .zero) {
+        previewItem = ChatImageQuickLookPreviewItem(url: localURL, title: title)
+        self.sourceFrame = sourceFrame
+
+        guard let panel = QLPreviewPanel.shared() else { return }
+        panel.dataSource = self
+        panel.delegate = self
+        panel.makeKeyAndOrderFront(nil)
+        panel.reloadData()
+        panel.currentPreviewItemIndex = 0
+        panel.refreshCurrentPreviewItem()
+    }
+
+    func numberOfPreviewItems(in panel: QLPreviewPanel!) -> Int {
+        previewItem == nil ? 0 : 1
+    }
+
+    func previewPanel(_ panel: QLPreviewPanel!, previewItemAt index: Int) -> QLPreviewItem! {
+        previewItem
+    }
+
+    func previewPanel(_ panel: QLPreviewPanel!, sourceFrameOnScreenFor previewItem: QLPreviewItem!) -> NSRect {
+        sourceFrame
+    }
+}
+
+private struct ChatQuickLookSpaceKeyMonitor: NSViewRepresentable {
+    let isEnabled: Bool
+    let onSpace: () -> Void
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(isEnabled: isEnabled, onSpace: onSpace)
+    }
+
+    func makeNSView(context: Context) -> NSView {
+        let view = NSView(frame: .zero)
+        context.coordinator.attach(to: view)
+        return view
+    }
+
+    func updateNSView(_ nsView: NSView, context: Context) {
+        context.coordinator.attach(to: nsView)
+        context.coordinator.isEnabled = isEnabled
+        context.coordinator.onSpace = onSpace
+    }
+
+    static func dismantleNSView(_ nsView: NSView, coordinator: Coordinator) {
+        coordinator.detach()
+    }
+
+    final class Coordinator {
+        var isEnabled: Bool
+        var onSpace: () -> Void
+        private weak var view: NSView?
+        private var monitor: Any?
+
+        init(isEnabled: Bool, onSpace: @escaping () -> Void) {
+            self.isEnabled = isEnabled
+            self.onSpace = onSpace
+        }
+
+        deinit {
+            detach()
+        }
+
+        func attach(to view: NSView) {
+            self.view = view
+            guard monitor == nil else { return }
+
+            monitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
+                guard let self else { return event }
+                guard self.isEnabled else { return event }
+                guard self.view?.window?.isKeyWindow == true else { return event }
+                guard event.modifierFlags.intersection(.deviceIndependentFlagsMask).isEmpty,
+                      event.keyCode == 49 else {
+                    return event
+                }
+
+                if let textView = self.view?.window?.firstResponder as? NSTextView,
+                   textView.isEditable {
+                    return event
+                }
+
+                self.onSpace()
+                return nil
+            }
+        }
+
+        func detach() {
+            if let monitor {
+                NSEvent.removeMonitor(monitor)
+                self.monitor = nil
+            }
+        }
+    }
+}
+#endif
+
 struct ChatAttachmentImageBubbleView: View {
     @Environment(ConnectionRuntime.self) private var runtime
 
     let attachment: ChatAttachmentDescriptor
     let isFromYou: Bool
     let showsTail: Bool
+    var isSelected: Bool = false
+    var onSelect: (() -> Void)?
+    var onOpenQuickLook: (() -> Void)?
 
     @State private var phase: Phase = .idle
 
@@ -97,6 +298,15 @@ struct ChatAttachmentImageBubbleView: View {
             .frame(width: currentSize.width, height: currentSize.height)
             .mask(bubbleMask)
             .shadow(color: .black.opacity(0.06), radius: 1.5, y: 1)
+            .overlay(selectionOverlay)
+            .contentShape(Rectangle())
+            .onTapGesture {
+                onSelect?()
+            }
+            .onTapGesture(count: 2) {
+                onSelect?()
+                onOpenQuickLook?()
+            }
             .contextMenu {
 #if os(macOS)
                 Button {
@@ -109,6 +319,12 @@ struct ChatAttachmentImageBubbleView: View {
             .task(id: attachment.id) {
                 await load()
             }
+    }
+
+    private var selectionOverlay: some View {
+        RoundedRectangle(cornerRadius: 18, style: .continuous)
+            .stroke(Color.accentColor.opacity(isSelected ? 0.35 : 0), lineWidth: 1)
+            .padding(1)
     }
 
     private var bubbleContent: some View {
@@ -309,3 +525,27 @@ struct ChatAttachmentFileBubbleView: View {
     }
 #endif
 }
+
+#if os(macOS)
+extension View {
+    @ViewBuilder
+    func chatQuickLookSpaceMonitor(
+        isEnabled: Bool,
+        onSpace: @escaping () -> Void
+    ) -> some View {
+        background(
+            ChatQuickLookSpaceKeyMonitor(
+                isEnabled: isEnabled,
+                onSpace: onSpace
+            )
+            .frame(width: 0, height: 0)
+        )
+    }
+}
+
+private extension String {
+    var nilIfEmpty: String? {
+        isEmpty ? nil : self
+    }
+}
+#endif

--- a/Wired 3/Features/Chats/Views/ChatMeMessageView.swift
+++ b/Wired 3/Features/Chats/Views/ChatMeMessageView.swift
@@ -13,6 +13,9 @@ struct ChatMeMessageView: View {
     @AppStorage("TimestampEveryMessage") var timestampEveryMessage: Bool = false
 
     var message: ChatEvent
+    var selectedImageSource: ChatImageQuickLookSource?
+    var onSelectImage: ((ChatImageQuickLookSource) -> Void)?
+    var onOpenQuickLook: ((ChatImageQuickLookSource) -> Void)?
 
     private var imageAttachments: [ChatAttachmentDescriptor] {
         message.attachments.filter(\.isImage)
@@ -55,9 +58,21 @@ struct ChatMeMessageView: View {
             }
 
             ForEach(imageAttachments, id: \.id) { attachment in
+                let source = ChatImageQuickLookSource.attachment(attachment)
                 HStack {
                     Spacer()
-                    ChatAttachmentImageBubbleView(attachment: attachment, isFromYou: false, showsTail: false)
+                    ChatAttachmentImageBubbleView(
+                        attachment: attachment,
+                        isFromYou: false,
+                        showsTail: false,
+                        isSelected: selectedImageSource?.selectionID == source.selectionID,
+                        onSelect: {
+                            onSelectImage?(source)
+                        },
+                        onOpenQuickLook: {
+                            onOpenQuickLook?(source)
+                        }
+                    )
                     Spacer()
                 }
             }

--- a/Wired 3/Features/Chats/Views/ChatMeMessageView.swift
+++ b/Wired 3/Features/Chats/Views/ChatMeMessageView.swift
@@ -14,34 +14,60 @@ struct ChatMeMessageView: View {
 
     var message: ChatEvent
 
+    private var imageAttachments: [ChatAttachmentDescriptor] {
+        message.attachments.filter(\.isImage)
+    }
+
+    private var fileAttachments: [ChatAttachmentDescriptor] {
+        message.attachments.filter { !$0.isImage }
+    }
+
     var body: some View {
-        HStack(alignment: .bottom) {
-            if timestampEveryMessage {
-                RelativeDateText(date: message.date)
-                    .foregroundStyle(.clear)
-                    .monospacedDigit()
+        VStack(spacing: 6) {
+            HStack(alignment: .bottom) {
+                if timestampEveryMessage {
+                    RelativeDateText(date: message.date)
+                        .foregroundStyle(.clear)
+                        .monospacedDigit()
+                        .font(.caption)
+                }
+
+                Spacer()
+
+                (
+                    Text("**\(message.user.nick)** ")
+                    +
+                    Text(message.text.attributedWithDetectedLinks(linkColor: .blue))
+                )
+                    .multilineTextAlignment(.center)
+                    .frame(maxWidth: .infinity)
+                    .foregroundStyle(.gray)
                     .font(.caption)
+
+                Spacer()
+
+                if timestampEveryMessage {
+                    HoverableRelativeDateText(date: message.date)
+                        .foregroundStyle(.gray)
+                        .monospacedDigit()
+                        .font(.caption)
+                }
             }
 
-            Spacer()
+            ForEach(imageAttachments, id: \.id) { attachment in
+                HStack {
+                    Spacer()
+                    ChatAttachmentImageBubbleView(attachment: attachment, isFromYou: false, showsTail: false)
+                    Spacer()
+                }
+            }
 
-            (
-                Text("**\(message.user.nick)** ")
-                +
-                Text(message.text.attributedWithDetectedLinks(linkColor: .blue))
-            )
-                .multilineTextAlignment(.center)
-                .frame(maxWidth: .infinity)
-                .foregroundStyle(.gray)
-                .font(.caption)
-
-            Spacer()
-
-            if timestampEveryMessage {
-                HoverableRelativeDateText(date: message.date)
-                    .foregroundStyle(.gray)
-                    .monospacedDigit()
-                    .font(.caption)
+            ForEach(fileAttachments, id: \.id) { attachment in
+                HStack {
+                    Spacer()
+                    ChatAttachmentFileBubbleView(attachment: attachment, isFromYou: false, showsTail: false)
+                    Spacer()
+                }
             }
         }
         .listRowSeparator(.hidden)

--- a/Wired 3/Features/Chats/Views/ChatMessagesView.swift
+++ b/Wired 3/Features/Chats/Views/ChatMessagesView.swift
@@ -28,6 +28,10 @@ struct ChatMessagesView: View {
     @State private var displayedMessageCount: Int = 100
     @State private var isLoadingMore = false
     @State private var archiveBoundaryMessageID: UUID?
+    @State private var selectedImageSource: ChatImageQuickLookSource?
+#if os(macOS)
+    @State private var quickLookController = ChatImageQuickLookController()
+#endif
 
     var chat: Chat
     var searchText: String = ""
@@ -235,6 +239,7 @@ struct ChatMessagesView: View {
         .onChange(of: chat.id) {
             displayedMessageCount = chatMaxMessages
             archiveBoundaryMessageID = nil
+            selectedImageSource = nil
         }
         .onChange(of: chatMaxMessages) { _, newMax in
             if displayedMessageCount < newMax {
@@ -294,6 +299,11 @@ struct ChatMessagesView: View {
             .background(.clear)
             .textSelection(.enabled)
             .frame(maxHeight: .infinity)
+#if os(macOS)
+            .chatQuickLookSpaceMonitor(isEnabled: selectedImageSource != nil) {
+                openSelectedImageQuickLook()
+            }
+#endif
             .onChange(of: chat.messages.last?.id) {
                 // When not searching: the last message is always in the windowed suffix.
                 // When searching: check directly — avoids building an O(n) Set on every call.
@@ -404,13 +414,31 @@ struct ChatMessagesView: View {
                 message: message,
                 showNickname: showNickname,
                 showAvatar: showAvatar,
-                isGroupedWithNext: isGroupedWithNext
+                isGroupedWithNext: isGroupedWithNext,
+                selectedImageSource: selectedImageSource,
+                onSelectImage: { source in
+                    selectedImageSource = source
+                },
+                onOpenQuickLook: { source in
+                    selectedImageSource = source
+                    openQuickLook(for: source)
+                }
             )
             .environment(runtime)
             .scaleEffect(message.id == animatedNewMessageID ? (revealNewMessage ? 1 : 0.94) : 1)
             .opacity(message.id == animatedNewMessageID ? (revealNewMessage ? 1 : 0) : 1)
         } else if message.type == .me {
-            ChatMeMessageView(message: message)
+            ChatMeMessageView(
+                message: message,
+                selectedImageSource: selectedImageSource,
+                onSelectImage: { source in
+                    selectedImageSource = source
+                },
+                onOpenQuickLook: { source in
+                    selectedImageSource = source
+                    openQuickLook(for: source)
+                }
+            )
                 .environment(runtime)
                 .scaleEffect(message.id == animatedNewMessageID ? (revealNewMessage ? 1 : 0.94) : 1)
                 .opacity(message.id == animatedNewMessageID ? (revealNewMessage ? 1 : 0) : 1)
@@ -692,6 +720,32 @@ struct ChatMessagesView: View {
         )
     }
 
+    private func openSelectedImageQuickLook() {
+#if os(macOS)
+        guard let selectedImageSource else { return }
+        openQuickLook(for: selectedImageSource)
+#endif
+    }
+
+    private func openQuickLook(for source: ChatImageQuickLookSource) {
+#if os(macOS)
+        Task {
+            do {
+                let localURL = try await source.quickLookURL(connectionID: runtime.id, runtime: runtime)
+                await MainActor.run {
+                    quickLookController.present(localURL: localURL, title: source.title)
+                }
+            } catch {
+                await MainActor.run {
+                    runtime.lastError = error
+                }
+            }
+        }
+#else
+        _ = source
+#endif
+    }
+
 }
 
 private enum ChatDisplayItem: Identifiable {
@@ -726,6 +780,7 @@ private enum ChatDisplayItem: Identifiable {
             return nil
         }
     }
+
 }
 
 private enum LiveSlotPresentation {

--- a/Wired 3/Features/Chats/Views/ChatSayMessageView.swift
+++ b/Wired 3/Features/Chats/Views/ChatSayMessageView.swift
@@ -425,20 +425,20 @@ struct ChatRemoteImageBubbleView: View {
     let url: URL
     let isFromYou: Bool
     let showsTail: Bool
+    var maxBubbleWidth: CGFloat = 280
+    var maxBubbleHeight: CGFloat = 360
     var isSelected: Bool = false
     var onSelect: (() -> Void)?
     var onOpenQuickLook: (() -> Void)?
 
     @StateObject private var loader: ChatRemoteImageLoader
 
-    private let maxBubbleWidth: CGFloat = 280
-    private let maxBubbleHeight: CGFloat = 360
-    private let placeholderSize = CGSize(width: 280, height: 190)
-
     init(
         url: URL,
         isFromYou: Bool,
         showsTail: Bool,
+        maxBubbleWidth: CGFloat = 280,
+        maxBubbleHeight: CGFloat = 360,
         isSelected: Bool = false,
         onSelect: (() -> Void)? = nil,
         onOpenQuickLook: (() -> Void)? = nil
@@ -446,6 +446,8 @@ struct ChatRemoteImageBubbleView: View {
         self.url = url
         self.isFromYou = isFromYou
         self.showsTail = showsTail
+        self.maxBubbleWidth = maxBubbleWidth
+        self.maxBubbleHeight = maxBubbleHeight
         self.isSelected = isSelected
         self.onSelect = onSelect
         self.onOpenQuickLook = onOpenQuickLook
@@ -470,6 +472,10 @@ struct ChatRemoteImageBubbleView: View {
             return resolvedSize(for: image)
         }
         return placeholderSize
+    }
+
+    private var placeholderSize: CGSize {
+        CGSize(width: maxBubbleWidth, height: min(maxBubbleHeight, maxBubbleWidth * 0.68))
     }
 
     var body: some View {

--- a/Wired 3/Features/Chats/Views/ChatSayMessageView.swift
+++ b/Wired 3/Features/Chats/Views/ChatSayMessageView.swift
@@ -21,6 +21,9 @@ struct ChatSayMessageView: View {
     var showNickname: Bool = true
     var showAvatar: Bool = true
     var isGroupedWithNext: Bool = false
+    var selectedImageSource: ChatImageQuickLookSource?
+    var onSelectImage: ((ChatImageQuickLookSource) -> Void)?
+    var onOpenQuickLook: ((ChatImageQuickLookSource) -> Void)?
 
     @State var isHovered: Bool = false
 
@@ -167,18 +170,34 @@ struct ChatSayMessageView: View {
             }
 
             if let primaryImageURL {
+                let source = ChatImageQuickLookSource.remote(primaryImageURL)
                 ChatRemoteImageBubbleView(
                     url: primaryImageURL,
                     isFromYou: isFromYou,
-                    showsTail: imageAttachments.isEmpty && fileAttachments.isEmpty && !isGroupedWithNext
+                    showsTail: imageAttachments.isEmpty && fileAttachments.isEmpty && !isGroupedWithNext,
+                    isSelected: selectedImageSource?.selectionID == source.selectionID,
+                    onSelect: {
+                        onSelectImage?(source)
+                    },
+                    onOpenQuickLook: {
+                        onOpenQuickLook?(source)
+                    }
                 )
             }
 
             ForEach(Array(imageAttachments.enumerated()), id: \.element.id) { index, attachment in
+                let source = ChatImageQuickLookSource.attachment(attachment)
                 ChatAttachmentImageBubbleView(
                     attachment: attachment,
                     isFromYou: isFromYou,
-                    showsTail: index == imageAttachments.count - 1 && fileAttachments.isEmpty && !isGroupedWithNext
+                    showsTail: index == imageAttachments.count - 1 && fileAttachments.isEmpty && !isGroupedWithNext,
+                    isSelected: selectedImageSource?.selectionID == source.selectionID,
+                    onSelect: {
+                        onSelectImage?(source)
+                    },
+                    onOpenQuickLook: {
+                        onOpenQuickLook?(source)
+                    }
                 )
             }
 
@@ -406,6 +425,9 @@ struct ChatRemoteImageBubbleView: View {
     let url: URL
     let isFromYou: Bool
     let showsTail: Bool
+    var isSelected: Bool = false
+    var onSelect: (() -> Void)?
+    var onOpenQuickLook: (() -> Void)?
 
     @StateObject private var loader: ChatRemoteImageLoader
 
@@ -413,10 +435,20 @@ struct ChatRemoteImageBubbleView: View {
     private let maxBubbleHeight: CGFloat = 360
     private let placeholderSize = CGSize(width: 280, height: 190)
 
-    init(url: URL, isFromYou: Bool, showsTail: Bool) {
+    init(
+        url: URL,
+        isFromYou: Bool,
+        showsTail: Bool,
+        isSelected: Bool = false,
+        onSelect: (() -> Void)? = nil,
+        onOpenQuickLook: (() -> Void)? = nil
+    ) {
         self.url = url
         self.isFromYou = isFromYou
         self.showsTail = showsTail
+        self.isSelected = isSelected
+        self.onSelect = onSelect
+        self.onOpenQuickLook = onOpenQuickLook
         _loader = StateObject(wrappedValue: ChatRemoteImageLoader(url: url))
     }
 
@@ -441,12 +473,18 @@ struct ChatRemoteImageBubbleView: View {
     }
 
     var body: some View {
-        Link(destination: url) {
-            bubbleContent
-        }
-        .buttonStyle(.plain)
+        bubbleContent
         .frame(width: currentSize.width, height: currentSize.height)
+        .overlay(selectionOverlay)
+        .contentShape(Rectangle())
         .contextMenu { contextMenuItems }
+        .onTapGesture {
+            onSelect?()
+        }
+        .onTapGesture(count: 2) {
+            onSelect?()
+            onOpenQuickLook?()
+        }
         .onAppear {
             loader.loadIfNeeded()
         }
@@ -516,6 +554,12 @@ struct ChatRemoteImageBubbleView: View {
         .frame(width: currentSize.width, height: currentSize.height)
         .mask(bubbleMask)
         .shadow(color: .black.opacity(0.06), radius: 1.5, y: 1)
+    }
+
+    private var selectionOverlay: some View {
+        RoundedRectangle(cornerRadius: 18, style: .continuous)
+            .stroke(Color.accentColor.opacity(isSelected ? 0.35 : 0), lineWidth: 1)
+            .padding(1)
     }
 
     private var bubbleMask: some View {

--- a/Wired 3/Features/Chats/Views/ChatSayMessageView.swift
+++ b/Wired 3/Features/Chats/Views/ChatSayMessageView.swift
@@ -28,6 +28,14 @@ struct ChatSayMessageView: View {
         message.cachedPrimaryHTTPImageURL
     }
 
+    private var imageAttachments: [ChatAttachmentDescriptor] {
+        message.attachments.filter(\.isImage)
+    }
+
+    private var fileAttachments: [ChatAttachmentDescriptor] {
+        message.attachments.filter { !$0.isImage }
+    }
+
     private var trimmedMessageText: String {
         message.text.trimmingCharacters(in: .whitespacesAndNewlines)
     }
@@ -38,7 +46,7 @@ struct ChatSayMessageView: View {
     }
 
     private var shouldShowTextBubble: Bool {
-        !isImageOnlyMessage
+        !trimmedMessageText.isEmpty && !isImageOnlyMessage
     }
 
     private var isEmojiOnlyMessage: Bool {
@@ -147,7 +155,7 @@ struct ChatSayMessageView: View {
                         isFromYou: isFromYou,
                         customFillColor: bubbleFillColor,
                         customForegroundColor: bubbleTextColor,
-                        showsTail: primaryImageURL == nil && !isGroupedWithNext
+                        showsTail: primaryImageURL == nil && imageAttachments.isEmpty && fileAttachments.isEmpty && !isGroupedWithNext
                     )
                     .containerRelativeFrame(
                         .horizontal,
@@ -162,7 +170,23 @@ struct ChatSayMessageView: View {
                 ChatRemoteImageBubbleView(
                     url: primaryImageURL,
                     isFromYou: isFromYou,
-                    showsTail: !isGroupedWithNext
+                    showsTail: imageAttachments.isEmpty && fileAttachments.isEmpty && !isGroupedWithNext
+                )
+            }
+
+            ForEach(Array(imageAttachments.enumerated()), id: \.element.id) { index, attachment in
+                ChatAttachmentImageBubbleView(
+                    attachment: attachment,
+                    isFromYou: isFromYou,
+                    showsTail: index == imageAttachments.count - 1 && fileAttachments.isEmpty && !isGroupedWithNext
+                )
+            }
+
+            ForEach(Array(fileAttachments.enumerated()), id: \.element.id) { index, attachment in
+                ChatAttachmentFileBubbleView(
+                    attachment: attachment,
+                    isFromYou: isFromYou,
+                    showsTail: index == fileAttachments.count - 1 && !isGroupedWithNext
                 )
             }
         }

--- a/Wired 3/Features/Chats/Views/ChatView.swift
+++ b/Wired 3/Features/Chats/Views/ChatView.swift
@@ -7,6 +7,7 @@
 //
 
 import SwiftUI
+import UniformTypeIdentifiers
 #if os(macOS)
 import AppKit
 #endif
@@ -21,9 +22,16 @@ struct ChatView: View {
 #if os(iOS)
     @State private var chatScrollTrigger: Int = 0
 #endif
+#if os(macOS)
+    @State private var isAttachmentDropTargeted = false
+#endif
 
     private var chatInput: String {
         runtime.chatDrafts[chat.id] ?? ""
+    }
+
+    private var chatDraftAttachments: [ChatDraftAttachment] {
+        runtime.chatDraftAttachments[chat.id] ?? []
     }
 
     private var chatInputBinding: Binding<String> {
@@ -50,10 +58,11 @@ struct ChatView: View {
     }
 
     private var composerOverlayInset: CGFloat {
+        let attachmentInset: CGFloat = chatDraftAttachments.isEmpty ? 0 : 42
 #if os(macOS)
-        58
+        return 58 + attachmentInset
 #else
-        76
+        return 76 + attachmentInset
 #endif
     }
 
@@ -85,43 +94,78 @@ struct ChatView: View {
                     .environment(runtime)
                     .frame(maxWidth: .infinity, alignment: .topLeading)
 
-                HStack(alignment: .top, spacing: 0) {
-                    ConversationComposer(
-                        text: chatInputBinding,
-                        placeholder: "Chat here…",
-                        isEnabled: true,
-                        onSend: { text in
-                            await runtime.setChatTyping(chatID: chat.id, isTyping: false)
-                            do {
-                                _ = try await runtime.sendChatMessage(chat.id, text)
-                            } catch {
-                                runtime.lastError = error
+                VStack(alignment: .leading, spacing: 6) {
+                    if !chatDraftAttachments.isEmpty {
+                        ScrollView(.horizontal, showsIndicators: false) {
+                            HStack(spacing: 8) {
+                                ForEach(chatDraftAttachments) { attachment in
+                                    ChatDraftAttachmentChipView(attachment: attachment) {
+                                        runtime.removeChatDraftAttachment(attachment, for: chat.id)
+                                    }
+                                }
                             }
-                        },
-                        onTextChanged: { newValue in
-                            handleComposerTextChanged(newValue)
-                        },
-                        onDisappear: {
-                            stopTypingUpdates(sendStopSignal: true)
+                            .padding(.leading, 10)
+                            .padding(.trailing, 8)
                         }
-                    )
+                    }
+
+                    HStack(alignment: .top, spacing: 0) {
+                        ConversationComposer(
+                            text: chatInputBinding,
+                            placeholder: chatDraftAttachments.isEmpty ? "Chat here…" : "Add a message or press Return to send…",
+                            isEnabled: true,
+                            allowsEmptySubmit: !chatDraftAttachments.isEmpty,
+                            onSend: { text in
+                                await runtime.setChatTyping(chatID: chat.id, isTyping: false)
+                                do {
+                                    _ = try await runtime.sendChatMessage(chat.id, text, attachments: chatDraftAttachments)
+                                    runtime.clearChatDraftAttachments(for: chat.id)
+                                } catch {
+                                    runtime.chatDrafts[chat.id] = text
+                                    runtime.lastError = error
+                                }
+                            },
+                            onTextChanged: { newValue in
+                                handleComposerTextChanged(newValue)
+                            },
+                            onDisappear: {
+                                stopTypingUpdates(sendStopSignal: true)
+                            }
+                        )
+                        .frame(maxWidth: .infinity, alignment: .leading)
 
 #if os(macOS)
-                    Button {
-                        NSApp.orderFrontCharacterPalette(nil)
-                    } label: {
-                        Image(systemName: "face.smiling")
-                            .font(.title3)
-                    }
-                    .foregroundColor(.gray)
-                    .buttonStyle(.plain)
-                    .padding(.top, 8)
-                    .padding(.trailing, 8)
+                        Button {
+                            NSApp.orderFrontCharacterPalette(nil)
+                        } label: {
+                            Image(systemName: "face.smiling")
+                                .font(.title3)
+                        }
+                        .foregroundColor(.gray)
+                        .buttonStyle(.plain)
+                        .padding(.top, 8)
+                        .padding(.trailing, 8)
 #endif
+                    }
                 }
                 .backgroundEdgeFade(top: 0, bottom: 60)
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomLeading)
             }
+#if os(macOS)
+            .overlay {
+                RoundedRectangle(cornerRadius: 18, style: .continuous)
+                    .stroke(Color.accentColor.opacity(isAttachmentDropTargeted ? 0.9 : 0), lineWidth: 4)
+                    .background(
+                        RoundedRectangle(cornerRadius: 18, style: .continuous)
+                            .fill(Color.accentColor.opacity(isAttachmentDropTargeted ? 0.08 : 0))
+                    )
+                    .padding(8)
+                    .allowsHitTesting(false)
+            }
+            .onDrop(of: [UTType.fileURL.identifier], isTargeted: $isAttachmentDropTargeted) { providers in
+                handleFileDrop(providers: providers)
+            }
+#endif
             .contentMargins(.bottom, 30, for: .scrollIndicators)
 
 #if os(macOS)
@@ -277,6 +321,44 @@ struct ChatView: View {
             await runtime.setChatTyping(chatID: chatID, isTyping: false)
         }
     }
+
+#if os(macOS)
+    private func handleFileDrop(providers: [NSItemProvider]) -> Bool {
+        let fileProviders = providers.filter {
+            $0.hasItemConformingToTypeIdentifier(UTType.fileURL.identifier)
+        }
+
+        guard !fileProviders.isEmpty else {
+            return false
+        }
+
+        for provider in fileProviders {
+            provider.loadDataRepresentation(forTypeIdentifier: UTType.fileURL.identifier) { data, error in
+                if let error {
+                    Task { @MainActor in
+                        runtime.lastError = error
+                    }
+                    return
+                }
+
+                guard let data,
+                      let fileURL = URL(dataRepresentation: data, relativeTo: nil) else {
+                    return
+                }
+
+                Task { @MainActor in
+                    do {
+                        try runtime.addChatDraftAttachment(fileURL, for: chat.id)
+                    } catch {
+                        runtime.lastError = error
+                    }
+                }
+            }
+        }
+
+        return true
+    }
+#endif
 }
 
 struct ConversationComposer: View {
@@ -284,6 +366,7 @@ struct ConversationComposer: View {
 
     let placeholder: String
     let isEnabled: Bool
+    var allowsEmptySubmit: Bool = false
     let onSend: (String) async -> Void
     var onTextChanged: ((String) -> Void)?
     var onDisappear: (() -> Void)?
@@ -331,6 +414,7 @@ struct ConversationComposer: View {
                         text: $text,
                         dynamicHeight: $inputHeight,
                         isEnabled: isEnabled,
+                        allowsEmptySubmit: allowsEmptySubmit,
                         onSubmit: {
                             submit()
                         },
@@ -403,16 +487,18 @@ struct ConversationComposer: View {
         guard isEnabled else { return }
 
         var value = text.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !value.isEmpty else { return }
+        guard !value.isEmpty || allowsEmptySubmit else { return }
 
-        if substituteEmoji {
+        if substituteEmoji, !value.isEmpty {
             value = value.replacingEmoticons(using: emojiSubstitutions)
         }
 
         let finalText = value
         Task { await onSend(finalText) }
 
-        messageHistory.append(finalText)
+        if !finalText.isEmpty {
+            messageHistory.append(finalText)
+        }
         historyIndex = nil
         historyDraft = ""
         text = ""
@@ -642,6 +728,7 @@ private struct ChatInputField: NSViewRepresentable {
     @Binding var text: String
     @Binding var dynamicHeight: CGFloat
     var isEnabled: Bool = true
+    var allowsEmptySubmit: Bool = false
 
     let onSubmit: () -> Void
     let onHistoryUp: () -> Void
@@ -653,7 +740,12 @@ private struct ChatInputField: NSViewRepresentable {
     var hasSuggestions: Bool = false
 
     func makeCoordinator() -> Coordinator {
-        Coordinator(text: $text, dynamicHeight: $dynamicHeight, onSubmit: onSubmit)
+        Coordinator(
+            text: $text,
+            dynamicHeight: $dynamicHeight,
+            allowsEmptySubmit: allowsEmptySubmit,
+            onSubmit: onSubmit
+        )
     }
 
     func makeNSView(context: Context) -> NSScrollView {
@@ -755,11 +847,13 @@ private struct ChatInputField: NSViewRepresentable {
         context.coordinator.onSuggestionSelect = onSuggestionSelect
         context.coordinator.onSuggestionDismiss = onSuggestionDismiss
         context.coordinator.hasSuggestions = hasSuggestions
+        context.coordinator.allowsEmptySubmit = allowsEmptySubmit
     }
 
     final class Coordinator: NSObject, NSTextViewDelegate {
         var textBinding: Binding<String>
         var dynamicHeightBinding: Binding<CGFloat>
+        var allowsEmptySubmit: Bool
         var onSubmit: () -> Void
         var onHistoryUp: (() -> Void)?
         var onHistoryDown: (() -> Void)?
@@ -774,9 +868,15 @@ private struct ChatInputField: NSViewRepresentable {
         private let maximumLineCount: CGFloat = 5
         private let minimumHeight: CGFloat = 22
 
-        init(text: Binding<String>, dynamicHeight: Binding<CGFloat>, onSubmit: @escaping () -> Void) {
+        init(
+            text: Binding<String>,
+            dynamicHeight: Binding<CGFloat>,
+            allowsEmptySubmit: Bool,
+            onSubmit: @escaping () -> Void
+        ) {
             self.textBinding = text
             self.dynamicHeightBinding = dynamicHeight
+            self.allowsEmptySubmit = allowsEmptySubmit
             self.onSubmit = onSubmit
         }
 
@@ -871,6 +971,8 @@ private struct ChatInputField: NSViewRepresentable {
                 if flags.contains(.shift) || flags.contains(.option) {
                     return false
                 } else {
+                    let trimmed = textView.string.trimmingCharacters(in: .whitespacesAndNewlines)
+                    guard !trimmed.isEmpty || allowsEmptySubmit else { return true }
                     onSubmit()
                     return true
                 }

--- a/Wired 3/Features/Files/AppKitFileBrowserSupport.swift
+++ b/Wired 3/Features/Files/AppKitFileBrowserSupport.swift
@@ -2,9 +2,81 @@
 import AppKit
 
 enum SyncContextMenuItemTag {
-    static let status = 9_101
-    static let toggle = 9_102
+    static let status  = 9_101
+    static let toggle  = 9_102
     static let syncNow = 9_103
+}
+
+/// Tag base for label submenu items: base + FileLabelValue.rawValue (0–7)
+enum LabelContextMenuItemTag {
+    static let submenu = 9_200
+    static let itemBase = 9_210  // 9_210 … 9_217
+}
+
+// MARK: - Label submenu factory
+
+/// Builds a "Label" NSMenuItem with a submenu containing one entry per FileLabelValue.
+/// Each entry carries a colored dot NSImage (drawn directly — SF symbols in menus are
+/// always rendered as monochrome templates on macOS).
+/// `target` must implement `contextSetLabel(_ sender: NSMenuItem)`.
+func makeLabelSubmenuItem(target: AnyObject) -> NSMenuItem {
+    let submenu = NSMenu(title: "Label")
+    for label in FileLabelValue.allCases {
+        let item = NSMenuItem(
+            title: label.title,
+            action: #selector(FileLabelMenuTarget.contextSetLabel(_:)),
+            keyEquivalent: ""
+        )
+        item.tag = LabelContextMenuItemTag.itemBase + Int(label.rawValue)
+        item.image = label.contextDotImage
+        item.target = target
+        submenu.addItem(item)
+    }
+
+    let parent = NSMenuItem(title: "Label", action: nil, keyEquivalent: "")
+    parent.tag = LabelContextMenuItemTag.submenu
+    parent.image = NSImage(systemSymbolName: "tag", accessibilityDescription: nil)
+    parent.submenu = submenu
+    return parent
+}
+
+/// Marker protocol so the selector compiles on both Coordinator types.
+@objc protocol FileLabelMenuTarget {
+    func contextSetLabel(_ sender: NSMenuItem)
+}
+
+// MARK: - Colored dot image for label menu items
+
+private extension FileLabelValue {
+    /// A 12×12 NSImage with the label color drawn directly.
+    /// Unlike SF symbols, bitmap NSImages in menu items preserve their colors.
+    var contextDotImage: NSImage {
+        NSImage(size: NSSize(width: 12, height: 12), flipped: false) { rect in
+            if self == .none {
+                NSColor.tertiaryLabelColor.setStroke()
+                let path = NSBezierPath(ovalIn: rect.insetBy(dx: 2, dy: 2))
+                path.lineWidth = 1.5
+                path.stroke()
+            } else {
+                self.swiftUIColor.setFill()
+                NSBezierPath(ovalIn: rect.insetBy(dx: 1, dy: 1)).fill()
+            }
+            return true
+        }
+    }
+
+    var swiftUIColor: NSColor {
+        switch self {
+        case .none:   return .secondaryLabelColor
+        case .red:    return .systemRed
+        case .orange: return .systemOrange
+        case .yellow: return .systemYellow
+        case .green:  return .systemGreen
+        case .blue:   return .systemBlue
+        case .purple: return .systemPurple
+        case .gray:   return .systemGray
+        }
+    }
 }
 
 var wiredRemotePathPasteboardType = NSPasteboard.PasteboardType("com.read-write.wired.remote-path")

--- a/Wired 3/Features/Files/AppKitFileColumnTableView.swift
+++ b/Wired 3/Features/Files/AppKitFileColumnTableView.swift
@@ -5,6 +5,38 @@ import UniformTypeIdentifiers
 import ObjectiveC
 import WiredSwift
 
+private final class FileLabelDotView: NSView {
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        wantsLayer = true
+        layer?.cornerRadius = min(frameRect.width, frameRect.height) / 2
+        layer?.masksToBounds = true
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        wantsLayer = true
+        layer?.masksToBounds = true
+    }
+
+    override func layout() {
+        super.layout()
+        layer?.cornerRadius = min(bounds.width, bounds.height) / 2
+    }
+
+    func configure(label: FileLabelValue) {
+        if label == .none {
+            isHidden = true
+            toolTip = nil
+            return
+        }
+
+        isHidden = false
+        layer?.backgroundColor = label.nsColor.cgColor
+        toolTip = label.title
+    }
+}
+
 private final class QuickLookTableView: NSTableView {
     var onQuickLook: (() -> Void)?
 
@@ -125,7 +157,7 @@ struct AppKitFileColumnTableView: NSViewRepresentable {
         weak var scrollView: NSScrollView?
         private var items: [FileItem] = []
         private var byPath: [String: Int] = [:]
-        private var lastItemPaths: [String] = []
+        private var lastItemSnapshots: [String] = []
         private var lastSyncPairStatusVersion: Int = -1
         private var isApplyingSelectionFromSwiftUI = false
         private var contextDirectoryTarget: FileItem
@@ -170,11 +202,26 @@ struct AppKitFileColumnTableView: NSViewRepresentable {
             return min(max(220, ceil(paddedWidth)), 420)
         }
 
+        private func itemSnapshot(for item: FileItem) -> String {
+            let modified = item.modificationDate?.timeIntervalSinceReferenceDate ?? -1
+            return [
+                item.path,
+                item.name,
+                String(item.type.rawValue),
+                String(item.directoryCount),
+                String(item.hasDirectoryCount),
+                String(item.dataSize),
+                String(item.rsrcSize),
+                String(modified),
+                String(item.label.rawValue)
+            ].joined(separator: "|")
+        }
+
         func syncFromModel(items: [FileItem], selectedPaths: Set<String>, syncPairStatusVersion: Int) {
-            let newPaths = items.map(\.path)
-            let listChanged = newPaths != lastItemPaths
+            let newSnapshots = items.map(itemSnapshot(for:))
+            let listChanged = newSnapshots != lastItemSnapshots
             let syncStatusChanged = syncPairStatusVersion != lastSyncPairStatusVersion
-            lastItemPaths = newPaths
+            lastItemSnapshots = newSnapshots
             lastSyncPairStatusVersion = syncPairStatusVersion
             self.items = items
             var map: [String: Int] = [:]
@@ -229,6 +276,11 @@ struct AppKitFileColumnTableView: NSViewRepresentable {
                 icon.imageScaling = .scaleProportionallyUpOrDown
                 cell.imageView = icon
 
+                let labelDot = FileLabelDotView(frame: .zero)
+                labelDot.identifier = NSUserInterfaceItemIdentifier("FileLabelDot")
+                labelDot.translatesAutoresizingMaskIntoConstraints = false
+                cell.addSubview(labelDot)
+
                 let tf = NSTextField(labelWithString: "")
                 tf.translatesAutoresizingMaskIntoConstraints = false
                 tf.lineBreakMode = .byTruncatingMiddle
@@ -255,15 +307,19 @@ struct AppKitFileColumnTableView: NSViewRepresentable {
                     icon.centerYAnchor.constraint(equalTo: cell.centerYAnchor),
                     icon.widthAnchor.constraint(equalToConstant: 16),
                     icon.heightAnchor.constraint(equalToConstant: 16),
-                    tf.leadingAnchor.constraint(equalTo: icon.trailingAnchor, constant: 8),
+                    tf.leadingAnchor.constraint(equalTo: icon.trailingAnchor, constant: 6),
+                    labelDot.trailingAnchor.constraint(equalTo: cell.trailingAnchor, constant: -32),
+                    labelDot.centerYAnchor.constraint(equalTo: cell.centerYAnchor),
+                    labelDot.widthAnchor.constraint(equalToConstant: 8),
+                    labelDot.heightAnchor.constraint(equalToConstant: 8),
                     tf.trailingAnchor.constraint(lessThanOrEqualTo: statusIcon.leadingAnchor, constant: -6),
                     tf.trailingAnchor.constraint(lessThanOrEqualTo: statusSpinner.leadingAnchor, constant: -6),
                     tf.centerYAnchor.constraint(equalTo: cell.centerYAnchor),
-                    statusIcon.trailingAnchor.constraint(equalTo: cell.trailingAnchor, constant: -10),
+                    statusIcon.trailingAnchor.constraint(equalTo: labelDot.leadingAnchor, constant: -8),
                     statusIcon.centerYAnchor.constraint(equalTo: cell.centerYAnchor),
                     statusIcon.widthAnchor.constraint(equalToConstant: 16),
                     statusIcon.heightAnchor.constraint(equalToConstant: 16),
-                    statusSpinner.trailingAnchor.constraint(equalTo: cell.trailingAnchor, constant: -10),
+                    statusSpinner.trailingAnchor.constraint(equalTo: labelDot.leadingAnchor, constant: -8),
                     statusSpinner.centerYAnchor.constraint(equalTo: cell.centerYAnchor),
                     statusSpinner.widthAnchor.constraint(equalToConstant: 16),
                     statusSpinner.heightAnchor.constraint(equalToConstant: 16)
@@ -273,6 +329,9 @@ struct AppKitFileColumnTableView: NSViewRepresentable {
 
             cell.textField?.stringValue = item.name
             cell.imageView?.image = remoteItemIconImage(for: item, size: 16)
+            let labelDot = cell.subviews.compactMap { $0 as? FileLabelDotView }
+                .first(where: { $0.identifier == NSUserInterfaceItemIdentifier("FileLabelDot") })
+            labelDot?.configure(label: item.label)
             let statusIcon = cell.subviews.compactMap { $0 as? NSImageView }
                 .first(where: { $0.identifier == NSUserInterfaceItemIdentifier("SyncStatusIcon") })
             let statusSpinner = cell.subviews.compactMap { $0 as? NSProgressIndicator }
@@ -670,6 +729,29 @@ struct AppKitFileColumnTableView: NSViewRepresentable {
         @objc private func contextNewFolder() {
             guard parent.canCreateFolderInDirectory(contextDirectoryTarget) else { return }
             parent.onRequestCreateFolder(contextDirectoryTarget)
+        }
+    }
+}
+
+private extension FileLabelValue {
+    var nsColor: NSColor {
+        switch self {
+        case .none:
+            return .secondaryLabelColor
+        case .red:
+            return .systemRed
+        case .orange:
+            return .systemOrange
+        case .yellow:
+            return .systemYellow
+        case .green:
+            return .systemGreen
+        case .blue:
+            return .systemBlue
+        case .purple:
+            return .systemPurple
+        case .gray:
+            return .systemGray
         }
     }
 }

--- a/Wired 3/Features/Files/AppKitFileColumnTableView.swift
+++ b/Wired 3/Features/Files/AppKitFileColumnTableView.swift
@@ -79,8 +79,11 @@ struct AppKitFileColumnTableView: NSViewRepresentable {
     let canDeleteForItem: (FileItem) -> Bool
     let canUploadToDirectory: (FileItem) -> Bool
     let canCreateFolderInDirectory: (FileItem) -> Bool
+    let canSetLabel: Bool
+    let onRequestSetLabel: ([FileItem], FileLabelValue) -> Void
     let savedScrollOffset: CGFloat
     let onScrollOffsetChange: (CGFloat) -> Void
+    let onDesiredWidthChange: (CGFloat) -> Void
 
     func makeCoordinator() -> Coordinator {
         Coordinator(parent: self)
@@ -151,7 +154,7 @@ struct AppKitFileColumnTableView: NSViewRepresentable {
         context.coordinator.syncFromModel(items: self.column.items, selectedPaths: selectedPaths, syncPairStatusVersion: syncPairStatusVersion)
     }
 
-    final class Coordinator: NSObject, NSTableViewDataSource, NSTableViewDelegate, NSMenuDelegate {
+    final class Coordinator: NSObject, NSTableViewDataSource, NSTableViewDelegate, NSMenuDelegate, FileLabelMenuTarget {
         var parent: AppKitFileColumnTableView
         weak var tableView: NSTableView?
         weak var scrollView: NSScrollView?
@@ -230,8 +233,15 @@ struct AppKitFileColumnTableView: NSViewRepresentable {
             }
             self.byPath = map
             contextDirectoryTarget = columnDirectory()
-            if let tableColumn = tableView?.tableColumns.first {
-                tableColumn.width = desiredColumnWidth(for: items)
+            if let tv = tableView, let tableColumn = tv.tableColumns.first {
+                let desired = desiredColumnWidth(for: items)
+                tableColumn.minWidth = 180
+                tv.sizeLastColumnToFit()
+                // Notify SwiftUI so it widens the column frame to fit the content.
+                // Deferred to avoid mutating state during a view update pass.
+                DispatchQueue.main.async { [weak self] in
+                    self?.parent.onDesiredWidthChange(desired)
+                }
             }
             if listChanged {
                 tableView?.reloadData()
@@ -302,13 +312,25 @@ struct AppKitFileColumnTableView: NSViewRepresentable {
                 statusSpinner.isDisplayedWhenStopped = false
                 cell.addSubview(statusSpinner)
 
+                let chevron = NSImageView()
+                chevron.identifier = NSUserInterfaceItemIdentifier("ChevronView")
+                chevron.translatesAutoresizingMaskIntoConstraints = false
+                chevron.imageScaling = .scaleProportionallyUpOrDown
+                chevron.image = NSImage(systemSymbolName: "chevron.right", accessibilityDescription: nil)
+                chevron.contentTintColor = .tertiaryLabelColor
+                cell.addSubview(chevron)
+
                 NSLayoutConstraint.activate([
                     icon.leadingAnchor.constraint(equalTo: cell.leadingAnchor, constant: 2),
                     icon.centerYAnchor.constraint(equalTo: cell.centerYAnchor),
                     icon.widthAnchor.constraint(equalToConstant: 16),
                     icon.heightAnchor.constraint(equalToConstant: 16),
                     tf.leadingAnchor.constraint(equalTo: icon.trailingAnchor, constant: 6),
-                    labelDot.trailingAnchor.constraint(equalTo: cell.trailingAnchor, constant: -32),
+                    chevron.trailingAnchor.constraint(equalTo: cell.trailingAnchor, constant: -6),
+                    chevron.centerYAnchor.constraint(equalTo: cell.centerYAnchor),
+                    chevron.widthAnchor.constraint(equalToConstant: 7),
+                    chevron.heightAnchor.constraint(equalToConstant: 11),
+                    labelDot.trailingAnchor.constraint(equalTo: chevron.leadingAnchor, constant: -5),
                     labelDot.centerYAnchor.constraint(equalTo: cell.centerYAnchor),
                     labelDot.widthAnchor.constraint(equalToConstant: 8),
                     labelDot.heightAnchor.constraint(equalToConstant: 8),
@@ -332,6 +354,9 @@ struct AppKitFileColumnTableView: NSViewRepresentable {
             let labelDot = cell.subviews.compactMap { $0 as? FileLabelDotView }
                 .first(where: { $0.identifier == NSUserInterfaceItemIdentifier("FileLabelDot") })
             labelDot?.configure(label: item.label)
+            let chevronView = cell.subviews.compactMap { $0 as? NSImageView }
+                .first(where: { $0.identifier == NSUserInterfaceItemIdentifier("ChevronView") })
+            chevronView?.isHidden = !isDirectory(item)
             let statusIcon = cell.subviews.compactMap { $0 as? NSImageView }
                 .first(where: { $0.identifier == NSUserInterfaceItemIdentifier("SyncStatusIcon") })
             let statusSpinner = cell.subviews.compactMap { $0 as? NSProgressIndicator }
@@ -570,21 +595,39 @@ struct AppKitFileColumnTableView: NSViewRepresentable {
         func makeContextMenu() -> NSMenu {
             let menu = NSMenu()
             menu.autoenablesItems = false
-            menu.addItem(withTitle: "Quick Look", action: #selector(contextQuickLook), keyEquivalent: "")
+            var item = menu.addItem(withTitle: "Get Info", action: #selector(contextGetInfo), keyEquivalent: "")
+            item.image = NSImage(systemSymbolName: "info.circle", accessibilityDescription: nil)
+            
+            item = menu.addItem(withTitle: "Quick Look", action: #selector(contextQuickLook), keyEquivalent: "")
+            item.image = NSImage(systemSymbolName: "eye", accessibilityDescription: nil)
+            
             menu.addItem(NSMenuItem.separator())
-            menu.addItem(withTitle: "Download", action: #selector(contextDownload), keyEquivalent: "")
-            menu.addItem(withTitle: "Delete", action: #selector(contextDelete), keyEquivalent: "")
-            menu.addItem(withTitle: "Upload…", action: #selector(contextUpload), keyEquivalent: "")
-            menu.addItem(withTitle: "Get Info", action: #selector(contextGetInfo), keyEquivalent: "")
+            item = menu.addItem(withTitle: "New Folder", action: #selector(contextNewFolder), keyEquivalent: "")
+            item.image = NSImage(systemSymbolName: "folder.badge.plus", accessibilityDescription: nil)
+            
+            item = menu.addItem(withTitle: "Download", action: #selector(contextDownload), keyEquivalent: "")
+            item.image = NSImage(systemSymbolName: "arrow.down.circle", accessibilityDescription: nil)
+            
+            item = menu.addItem(withTitle: "Upload…", action: #selector(contextUpload), keyEquivalent: "")
+            item.image = NSImage(systemSymbolName: "arrow.up.circle", accessibilityDescription: nil)
+
+            menu.addItem(makeLabelSubmenuItem(target: self))
+
+            menu.addItem(NSMenuItem.separator())
+            item = menu.addItem(withTitle: "Delete", action: #selector(contextDelete), keyEquivalent: "")
+            item.image = NSImage(systemSymbolName: "trash", accessibilityDescription: nil)
+            
             menu.addItem(NSMenuItem.separator())
             let statusItem = menu.addItem(withTitle: "Sync Status: Pair inactive", action: nil, keyEquivalent: "")
             statusItem.tag = SyncContextMenuItemTag.status
             let toggleItem = menu.addItem(withTitle: "Activate Sync Pair", action: #selector(contextToggleSyncPair), keyEquivalent: "")
             toggleItem.tag = SyncContextMenuItemTag.toggle
+            toggleItem.image = NSImage(systemSymbolName: "link", accessibilityDescription: nil)
+            
             let syncNowItem = menu.addItem(withTitle: "Sync Now", action: #selector(contextSyncNow), keyEquivalent: "")
             syncNowItem.tag = SyncContextMenuItemTag.syncNow
-            menu.addItem(NSMenuItem.separator())
-            menu.addItem(withTitle: "New Folder", action: #selector(contextNewFolder), keyEquivalent: "")
+            syncNowItem.image = NSImage(systemSymbolName: "arrow.trianglehead.2.clockwise", accessibilityDescription: nil)
+            
             for item in menu.items {
                 item.target = self
             }
@@ -672,6 +715,9 @@ struct AppKitFileColumnTableView: NSViewRepresentable {
             menu.item(withTag: SyncContextMenuItemTag.syncNow)?.isHidden = selectedSyncItem == nil
             menu.item(withTag: SyncContextMenuItemTag.syncNow)?.isEnabled = selectedSyncItem != nil && pairExists && syncState != .checking
             menu.item(withTitle: "New Folder")?.isEnabled = parent.canCreateFolderInDirectory(contextDirectoryTarget)
+            if let labelItem = menu.item(withTag: LabelContextMenuItemTag.submenu) {
+                labelItem.isEnabled = parent.canSetLabel && !selectedItems().isEmpty
+            }
         }
 
         private func selectedItems() -> [FileItem] {
@@ -729,6 +775,14 @@ struct AppKitFileColumnTableView: NSViewRepresentable {
         @objc private func contextNewFolder() {
             guard parent.canCreateFolderInDirectory(contextDirectoryTarget) else { return }
             parent.onRequestCreateFolder(contextDirectoryTarget)
+        }
+
+        @objc func contextSetLabel(_ sender: NSMenuItem) {
+            let rawValue = UInt32(sender.tag - LabelContextMenuItemTag.itemBase)
+            let label = FileLabelValue(rawValue: rawValue) ?? .none
+            let targets = selectedItems()
+            guard !targets.isEmpty else { return }
+            parent.onRequestSetLabel(targets, label)
         }
     }
 }

--- a/Wired 3/Features/Files/AppKitFilesTreeView.swift
+++ b/Wired 3/Features/Files/AppKitFilesTreeView.swift
@@ -92,6 +92,8 @@ struct AppKitFilesTreeView: NSViewRepresentable {
     let canDeleteForItem: (FileItem) -> Bool
     let canUploadToDirectory: (FileItem) -> Bool
     let canCreateFolderInDirectory: (FileItem) -> Bool
+    let canSetLabel: Bool
+    let onRequestSetLabel: ([FileItem], FileLabelValue) -> Void
     let savedScrollOffset: CGPoint
     let onScrollOffsetChange: (CGPoint) -> Void
 
@@ -1024,21 +1026,39 @@ struct AppKitFilesTreeView: NSViewRepresentable {
         func makeContextMenu() -> NSMenu {
             let menu = NSMenu()
             menu.autoenablesItems = false
-            menu.addItem(withTitle: "Quick Look", action: #selector(contextQuickLook), keyEquivalent: "")
+            var item = menu.addItem(withTitle: "Get Info", action: #selector(contextGetInfo), keyEquivalent: "")
+            item.image = NSImage(systemSymbolName: "info.circle", accessibilityDescription: nil)
+            
+            item = menu.addItem(withTitle: "Quick Look", action: #selector(contextQuickLook), keyEquivalent: "")
+            item.image = NSImage(systemSymbolName: "eye", accessibilityDescription: nil)
+            
             menu.addItem(NSMenuItem.separator())
-            menu.addItem(withTitle: "Download", action: #selector(contextDownload), keyEquivalent: "")
-            menu.addItem(withTitle: "Delete", action: #selector(contextDelete), keyEquivalent: "")
-            menu.addItem(withTitle: "Upload…", action: #selector(contextUpload), keyEquivalent: "")
-            menu.addItem(withTitle: "Get Info", action: #selector(contextGetInfo), keyEquivalent: "")
+            item = menu.addItem(withTitle: "New Folder", action: #selector(contextNewFolder), keyEquivalent: "")
+            item.image = NSImage(systemSymbolName: "folder.badge.plus", accessibilityDescription: nil)
+            
+            item = menu.addItem(withTitle: "Download", action: #selector(contextDownload), keyEquivalent: "")
+            item.image = NSImage(systemSymbolName: "arrow.down.circle", accessibilityDescription: nil)
+            
+            item = menu.addItem(withTitle: "Upload…", action: #selector(contextUpload), keyEquivalent: "")
+            item.image = NSImage(systemSymbolName: "arrow.up.circle", accessibilityDescription: nil)
+
+            menu.addItem(makeLabelSubmenuItem(target: self))
+
+            menu.addItem(NSMenuItem.separator())
+            item = menu.addItem(withTitle: "Delete", action: #selector(contextDelete), keyEquivalent: "")
+            item.image = NSImage(systemSymbolName: "trash", accessibilityDescription: nil)
+            
             menu.addItem(NSMenuItem.separator())
             let statusItem = menu.addItem(withTitle: "Sync Status: Pair inactive", action: nil, keyEquivalent: "")
             statusItem.tag = SyncContextMenuItemTag.status
             let toggleItem = menu.addItem(withTitle: "Activate Sync Pair", action: #selector(contextToggleSyncPair), keyEquivalent: "")
             toggleItem.tag = SyncContextMenuItemTag.toggle
+            toggleItem.image = NSImage(systemSymbolName: "link", accessibilityDescription: nil)
+            
             let syncNowItem = menu.addItem(withTitle: "Sync Now", action: #selector(contextSyncNow), keyEquivalent: "")
             syncNowItem.tag = SyncContextMenuItemTag.syncNow
-            menu.addItem(NSMenuItem.separator())
-            menu.addItem(withTitle: "New Folder", action: #selector(contextNewFolder), keyEquivalent: "")
+            syncNowItem.image = NSImage(systemSymbolName: "arrow.trianglehead.2.clockwise", accessibilityDescription: nil)
+            
             for item in menu.items {
                 item.target = self
             }
@@ -1158,6 +1178,9 @@ struct AppKitFilesTreeView: NSViewRepresentable {
             if let newFolderItem = menu.item(withTitle: "New Folder") {
                 newFolderItem.isEnabled = parent.canCreateFolderInDirectory(contextDirectoryTarget)
             }
+            if let labelItem = menu.item(withTag: LabelContextMenuItemTag.submenu) {
+                labelItem.isEnabled = parent.canSetLabel && !selectedItems.isEmpty
+            }
         }
 
         @objc private func contextQuickLook() { presentQuickLook() }
@@ -1195,6 +1218,14 @@ struct AppKitFilesTreeView: NSViewRepresentable {
         @objc private func contextNewFolder() {
             guard parent.canCreateFolderInDirectory(contextDirectoryTarget) else { return }
             parent.onRequestCreateFolder()
+        }
+
+        @objc func contextSetLabel(_ sender: NSMenuItem) {
+            let rawValue = UInt32(sender.tag - LabelContextMenuItemTag.itemBase)
+            let label = FileLabelValue(rawValue: rawValue) ?? .none
+            let targets = selectedItems()
+            guard !targets.isEmpty else { return }
+            parent.onRequestSetLabel(targets, label)
         }
     }
 }

--- a/Wired 3/Features/Files/AppKitFilesTreeView.swift
+++ b/Wired 3/Features/Files/AppKitFilesTreeView.swift
@@ -142,24 +142,24 @@ struct AppKitFilesTreeView: NSViewRepresentable {
         let kindColumn = NSTableColumn(identifier: ColumnID.kind)
         kindColumn.title = "Kind"
         kindColumn.minWidth = 110
-        kindColumn.width = 140
-        kindColumn.resizingMask = .autoresizingMask
+        kindColumn.width = 110
+        kindColumn.resizingMask = .userResizingMask
         kindColumn.sortDescriptorPrototype = NSSortDescriptor(key: "kind", ascending: true)
         outlineView.addTableColumn(kindColumn)
 
         let modifiedColumn = NSTableColumn(identifier: ColumnID.modified)
         modifiedColumn.title = "Modified"
         modifiedColumn.minWidth = 140
-        modifiedColumn.width = 180
-        modifiedColumn.resizingMask = .autoresizingMask
+        modifiedColumn.width = 140
+        modifiedColumn.resizingMask = .userResizingMask
         modifiedColumn.sortDescriptorPrototype = NSSortDescriptor(key: "modified", ascending: false)
         outlineView.addTableColumn(modifiedColumn)
 
         let sizeColumn = NSTableColumn(identifier: ColumnID.size)
         sizeColumn.title = "Size"
-        sizeColumn.minWidth = 90
-        sizeColumn.width = 120
-        sizeColumn.resizingMask = .autoresizingMask
+        sizeColumn.minWidth = 100
+        sizeColumn.width = 100
+        sizeColumn.resizingMask = .userResizingMask
         sizeColumn.sortDescriptorPrototype = NSSortDescriptor(key: "size", ascending: true)
         outlineView.addTableColumn(sizeColumn)
 

--- a/Wired 3/Features/Files/AppKitFilesTreeView.swift
+++ b/Wired 3/Features/Files/AppKitFilesTreeView.swift
@@ -5,6 +5,38 @@ import UniformTypeIdentifiers
 import ObjectiveC
 import WiredSwift
 
+private final class TreeFileLabelDotView: NSView {
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        wantsLayer = true
+        layer?.cornerRadius = min(frameRect.width, frameRect.height) / 2
+        layer?.masksToBounds = true
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        wantsLayer = true
+        layer?.masksToBounds = true
+    }
+
+    override func layout() {
+        super.layout()
+        layer?.cornerRadius = min(bounds.width, bounds.height) / 2
+    }
+
+    func configure(label: FileLabelValue) {
+        if label == .none {
+            isHidden = true
+            toolTip = nil
+            return
+        }
+
+        isHidden = false
+        layer?.backgroundColor = label.nsColor.cgColor
+        toolTip = label.title
+    }
+}
+
 private final class QuickLookOutlineView: NSOutlineView {
     var onQuickLook: (() -> Void)?
 
@@ -414,7 +446,8 @@ struct AppKitFilesTreeView: NSViewRepresentable {
                     String(item.hasDirectoryCount),
                     String(item.dataSize),
                     String(item.rsrcSize),
-                    String(modified)
+                    String(modified),
+                    String(item.label.rawValue)
                 ].joined(separator: "|")
             }
         }
@@ -691,6 +724,11 @@ struct AppKitFilesTreeView: NSViewRepresentable {
                 icon.imageScaling = .scaleProportionallyUpOrDown
                 cell.imageView = icon
 
+                let labelDot = TreeFileLabelDotView(frame: .zero)
+                labelDot.identifier = NSUserInterfaceItemIdentifier("FileLabelDot")
+                labelDot.translatesAutoresizingMaskIntoConstraints = false
+                cell.addSubview(labelDot)
+
                 let tf = NSTextField(labelWithString: "")
                 tf.translatesAutoresizingMaskIntoConstraints = false
                 tf.lineBreakMode = .byTruncatingMiddle
@@ -718,14 +756,18 @@ struct AppKitFilesTreeView: NSViewRepresentable {
                     icon.widthAnchor.constraint(equalToConstant: 16),
                     icon.heightAnchor.constraint(equalToConstant: 16),
                     tf.leadingAnchor.constraint(equalTo: icon.trailingAnchor, constant: 6),
+                    labelDot.trailingAnchor.constraint(equalTo: cell.trailingAnchor, constant: -32),
+                    labelDot.centerYAnchor.constraint(equalTo: cell.centerYAnchor),
+                    labelDot.widthAnchor.constraint(equalToConstant: 8),
+                    labelDot.heightAnchor.constraint(equalToConstant: 8),
                     tf.trailingAnchor.constraint(lessThanOrEqualTo: statusIcon.leadingAnchor, constant: -6),
                     tf.trailingAnchor.constraint(lessThanOrEqualTo: statusSpinner.leadingAnchor, constant: -6),
                     tf.centerYAnchor.constraint(equalTo: cell.centerYAnchor),
-                    statusIcon.trailingAnchor.constraint(equalTo: cell.trailingAnchor, constant: -10),
+                    statusIcon.trailingAnchor.constraint(equalTo: labelDot.leadingAnchor, constant: -8),
                     statusIcon.centerYAnchor.constraint(equalTo: cell.centerYAnchor),
                     statusIcon.widthAnchor.constraint(equalToConstant: 16),
                     statusIcon.heightAnchor.constraint(equalToConstant: 16),
-                    statusSpinner.trailingAnchor.constraint(equalTo: cell.trailingAnchor, constant: -10),
+                    statusSpinner.trailingAnchor.constraint(equalTo: labelDot.leadingAnchor, constant: -8),
                     statusSpinner.centerYAnchor.constraint(equalTo: cell.centerYAnchor),
                     statusSpinner.widthAnchor.constraint(equalToConstant: 16),
                     statusSpinner.heightAnchor.constraint(equalToConstant: 16)
@@ -734,6 +776,9 @@ struct AppKitFilesTreeView: NSViewRepresentable {
             }()
             cell.textField?.stringValue = item.name
             cell.imageView?.image = remoteItemIconImage(for: item, size: 16)
+            let labelDot = cell.subviews.compactMap { $0 as? TreeFileLabelDotView }
+                .first(where: { $0.identifier == NSUserInterfaceItemIdentifier("FileLabelDot") })
+            labelDot?.configure(label: item.label)
 
             let statusIcon = cell.subviews.compactMap { $0 as? NSImageView }
                 .first(where: { $0.identifier == NSUserInterfaceItemIdentifier("SyncStatusIcon") })
@@ -1150,6 +1195,29 @@ struct AppKitFilesTreeView: NSViewRepresentable {
         @objc private func contextNewFolder() {
             guard parent.canCreateFolderInDirectory(contextDirectoryTarget) else { return }
             parent.onRequestCreateFolder()
+        }
+    }
+}
+
+private extension FileLabelValue {
+    var nsColor: NSColor {
+        switch self {
+        case .none:
+            return .secondaryLabelColor
+        case .red:
+            return .systemRed
+        case .orange:
+            return .systemOrange
+        case .yellow:
+            return .systemYellow
+        case .green:
+            return .systemGreen
+        case .blue:
+            return .systemBlue
+        case .purple:
+            return .systemPurple
+        case .gray:
+            return .systemGray
         }
     }
 }

--- a/Wired 3/Features/Files/FileInfoSheet.swift
+++ b/Wired 3/Features/Files/FileInfoSheet.swift
@@ -6,6 +6,9 @@
 //
 
 import SwiftUI
+#if os(macOS)
+import AppKit
+#endif
 
 private enum DropboxAccessLevel: String, CaseIterable, Identifiable {
     case denied
@@ -322,7 +325,11 @@ struct FileInfoSheet: View {
                         Button {
                             labelSelection = label
                         } label: {
-                            Text(label.title)
+                            Label {
+                                Text(label.title)
+                            } icon: {
+                                Image(nsImage: label.menuDotImage)
+                            }
                         }
                     }
                 } label: {
@@ -720,22 +727,34 @@ struct FileInfoSheet: View {
 private extension FileLabelValue {
     var color: Color {
         switch self {
-        case .none:
-            return Color.secondary
-        case .red:
-            return .red
-        case .orange:
-            return .orange
-        case .yellow:
-            return .yellow
-        case .green:
-            return .green
-        case .blue:
-            return .blue
-        case .purple:
-            return .purple
-        case .gray:
-            return .gray
+        case .none:   return Color.secondary
+        case .red:    return .red
+        case .orange: return .orange
+        case .yellow: return .yellow
+        case .green:  return .green
+        case .blue:   return .blue
+        case .purple: return .purple
+        case .gray:   return .gray
+        }
+    }
+
+    /// A pre-drawn NSImage circle used in menu items.
+    /// SF symbols in menus are always rendered as templates (black) on macOS,
+    /// so we draw the dot directly into an NSImage to preserve the color.
+    var menuDotImage: NSImage {
+        let size: CGFloat = 12
+        return NSImage(size: NSSize(width: size, height: size), flipped: false) { rect in
+            if self == .none {
+                NSColor.tertiaryLabelColor.setFill()
+                let path = NSBezierPath(ovalIn: rect.insetBy(dx: 1.5, dy: 1.5))
+                path.lineWidth = 1.5
+                NSColor.tertiaryLabelColor.setStroke()
+                path.stroke()
+            } else {
+                NSColor(self.color).setFill()
+                NSBezierPath(ovalIn: rect.insetBy(dx: 1, dy: 1)).fill()
+            }
+            return true
         }
     }
 }

--- a/Wired 3/Features/Files/FileInfoSheet.swift
+++ b/Wired 3/Features/Files/FileInfoSheet.swift
@@ -89,6 +89,8 @@ struct FileInfoSheet: View {
     @State private var syncMaxTreeSizeBytes: UInt64 = 0
     @State private var syncExcludePatterns: String = ""
     @State private var newName: String = ""
+    @State private var labelSelection: FileLabelValue = .none
+    @State private var commentText: String = ""
 
     init(filesViewModel: FilesViewModel, file: FileItem) {
         self.filesViewModel = filesViewModel
@@ -138,8 +140,21 @@ struct FileInfoSheet: View {
         !newName.isEmpty && newName != info.name
     }
 
+    private var hasLabelChange: Bool {
+        labelSelection != info.label
+    }
+
+    private var hasCommentChange: Bool {
+        commentText != info.comment
+    }
+
     private var hasChanges: Bool {
-        hasRenameChange || selectedTypeRawValue != info.type.rawValue || hasManagedPermissionChanges || hasSyncPolicyChanges
+        hasRenameChange
+        || hasLabelChange
+        || hasCommentChange
+        || selectedTypeRawValue != info.type.rawValue
+        || hasManagedPermissionChanges
+        || hasSyncPolicyChanges
     }
 
     private var canEditManagedPermissions: Bool {
@@ -149,9 +164,19 @@ struct FileInfoSheet: View {
 
     private var canSaveChanges: Bool {
         hasRenameChange
+        || (canEditLabel && hasLabelChange)
+        || (canEditComment && hasCommentChange)
         || (canEditType && selectedTypeRawValue != info.type.rawValue)
         || (canEditManagedPermissions && hasManagedPermissionChanges)
         || (canEditManagedPermissions && hasSyncPolicyChanges)
+    }
+
+    private var canEditLabel: Bool {
+        runtime.hasPrivilege("wired.account.file.set_label")
+    }
+
+    private var canEditComment: Bool {
+        runtime.hasPrivilege("wired.account.file.set_comment")
     }
 
     private var totalSizeString: String {
@@ -174,6 +199,7 @@ struct FileInfoSheet: View {
             ScrollView {
                 VStack(spacing: 12) {
                     headerCard
+                    metadataCard
 
                     if info.type == .file {
                         sizeCard
@@ -280,6 +306,65 @@ struct FileInfoSheet: View {
             .labelStyle(.titleAndIcon)
             .font(.caption2)
             .foregroundStyle(.tertiary)
+    }
+
+    // MARK: - Metadata Card
+
+    private var metadataCard: some View {
+        infoCard(title: "Metadata", systemImage: "tag") {
+            HStack {
+                Text("Label")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                Spacer()
+                Menu {
+                    ForEach(FileLabelValue.allCases) { label in
+                        Button {
+                            labelSelection = label
+                        } label: {
+                            Text(label.title)
+                        }
+                    }
+                } label: {
+                    HStack(spacing: 8) {
+                        Circle()
+                            .fill(labelSelection.color)
+                            .frame(width: 8, height: 8)
+                            .opacity(labelSelection == .none ? 0.35 : 1)
+                        Text(labelSelection.title)
+                            .foregroundStyle(.primary)
+                        Image(systemName: "chevron.up.chevron.down")
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                    }
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 6)
+                    .background(Color.primary.opacity(0.04))
+                    .clipShape(RoundedRectangle(cornerRadius: 8))
+                }
+                .disabled(!canEditLabel)
+            }
+            .padding(.horizontal, 14).padding(.vertical, 8)
+
+            cardDivider
+
+            VStack(alignment: .leading, spacing: 6) {
+                Text("Comment")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+
+                TextEditor(text: $commentText)
+                    .font(.body)
+                    .frame(minHeight: 84)
+                    .scrollContentBackground(.hidden)
+                    .disabled(!canEditComment)
+                    .foregroundStyle(canEditComment ? .primary : .secondary)
+                    .padding(8)
+                    .background(Color.primary.opacity(0.04))
+                    .clipShape(RoundedRectangle(cornerRadius: 8))
+            }
+            .padding(.horizontal, 14).padding(.vertical, 8)
+        }
     }
 
     // MARK: - Size Card
@@ -542,6 +627,8 @@ struct FileInfoSheet: View {
             }
             ownerSelection   = loadedInfo.owner
             groupSelection   = loadedInfo.group
+            labelSelection   = loadedInfo.label
+            commentText      = loadedInfo.comment
             ownerAccess      = .from(read: loadedInfo.ownerRead, write: loadedInfo.ownerWrite)
             groupAccess      = .from(read: loadedInfo.groupRead, write: loadedInfo.groupWrite)
             everyoneAccess   = .from(read: loadedInfo.everyoneRead, write: loadedInfo.everyoneWrite)
@@ -591,6 +678,14 @@ struct FileInfoSheet: View {
             if selectedType != info.type, canEditType {
                 try await filesViewModel.setFileType(path: info.path, type: selectedType)
             }
+            if hasLabelChange, canEditLabel {
+                try await filesViewModel.setFileLabel(path: info.path, label: labelSelection)
+                info.label = labelSelection
+            }
+            if hasCommentChange, canEditComment {
+                try await filesViewModel.setFileComment(path: info.path, comment: commentText)
+                info.comment = commentText
+            }
             if info.type.isManagedAccessType, hasManagedPermissionChanges, canEditManagedPermissions {
                 let permissions = DropboxPermissions(
                     owner: ownerSelection,
@@ -618,6 +713,29 @@ struct FileInfoSheet: View {
             dismiss()
         } catch {
             filesViewModel.error = error
+        }
+    }
+}
+
+private extension FileLabelValue {
+    var color: Color {
+        switch self {
+        case .none:
+            return Color.secondary
+        case .red:
+            return .red
+        case .orange:
+            return .orange
+        case .yellow:
+            return .yellow
+        case .green:
+            return .green
+        case .blue:
+            return .blue
+        case .purple:
+            return .purple
+        case .gray:
+            return .gray
         }
     }
 }

--- a/Wired 3/Features/Files/FileInfoSheet.swift
+++ b/Wired 3/Features/Files/FileInfoSheet.swift
@@ -725,19 +725,6 @@ struct FileInfoSheet: View {
 }
 
 private extension FileLabelValue {
-    var color: Color {
-        switch self {
-        case .none:   return Color.secondary
-        case .red:    return .red
-        case .orange: return .orange
-        case .yellow: return .yellow
-        case .green:  return .green
-        case .blue:   return .blue
-        case .purple: return .purple
-        case .gray:   return .gray
-        }
-    }
-
     /// A pre-drawn NSImage circle used in menu items.
     /// SF symbols in menus are always rendered as templates (black) on macOS,
     /// so we draw the dot directly into an NSImage to preserve the color.

--- a/Wired 3/Features/Files/FileItem.swift
+++ b/Wired 3/Features/Files/FileItem.swift
@@ -62,6 +62,52 @@ enum SyncModeValue: String, CaseIterable, Identifiable {
     }
 }
 
+enum FileLabelValue: UInt32, CaseIterable, Identifiable {
+    case none = 0
+    case red
+    case orange
+    case yellow
+    case green
+    case blue
+    case purple
+    case gray
+
+    var id: UInt32 { rawValue }
+
+    init(wiredValue: UInt32) {
+        self = FileLabelValue(rawValue: wiredValue) ?? .none
+    }
+
+    init(wiredLabel: File.FileLabel) {
+        self = FileLabelValue(rawValue: wiredLabel.rawValue) ?? .none
+    }
+
+    var wiredLabel: File.FileLabel {
+        File.FileLabel(rawValue: rawValue) ?? .LABEL_NONE
+    }
+
+    var title: String {
+        switch self {
+        case .none:
+            return "None"
+        case .red:
+            return "Red"
+        case .orange:
+            return "Orange"
+        case .yellow:
+            return "Yellow"
+        case .green:
+            return "Green"
+        case .blue:
+            return "Blue"
+        case .purple:
+            return "Purple"
+        case .gray:
+            return "Gray"
+        }
+    }
+}
+
 public struct FileItem: Identifiable, Hashable {
     public let id = UUID()
     var name: String = ""
@@ -76,6 +122,7 @@ public struct FileItem: Identifiable, Hashable {
     var rsrcSize: UInt64 = 0
     var creationDate: Date?
     var modificationDate: Date?
+    var label: FileLabelValue = .none
     var comment: String = ""
     var owner: String = ""
     var group: String = ""
@@ -132,6 +179,9 @@ public struct FileItem: Identifiable, Hashable {
         }
         if let date = message.date(forField: "wired.file.modification_time") {
             self.modificationDate = date
+        }
+        if let value = message.uint32(forField: "wired.file.label") {
+            self.label = FileLabelValue(wiredValue: value)
         }
         if let value = message.string(forField: "wired.file.comment") {
             self.comment = value

--- a/Wired 3/Features/Files/FileItem.swift
+++ b/Wired 3/Features/Files/FileItem.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import SwiftUI
 import WiredSwift
 
 enum FileType: UInt32, CustomStringConvertible {
@@ -88,22 +89,27 @@ enum FileLabelValue: UInt32, CaseIterable, Identifiable {
 
     var title: String {
         switch self {
-        case .none:
-            return "None"
-        case .red:
-            return "Red"
-        case .orange:
-            return "Orange"
-        case .yellow:
-            return "Yellow"
-        case .green:
-            return "Green"
-        case .blue:
-            return "Blue"
-        case .purple:
-            return "Purple"
-        case .gray:
-            return "Gray"
+        case .none:   return "None"
+        case .red:    return "Red"
+        case .orange: return "Orange"
+        case .yellow: return "Yellow"
+        case .green:  return "Green"
+        case .blue:   return "Blue"
+        case .purple: return "Purple"
+        case .gray:   return "Gray"
+        }
+    }
+
+    var color: Color {
+        switch self {
+        case .none:   return .secondary
+        case .red:    return .red
+        case .orange: return .orange
+        case .yellow: return .yellow
+        case .green:  return .green
+        case .blue:   return .blue
+        case .purple: return .purple
+        case .gray:   return .gray
         }
     }
 }

--- a/Wired 3/Features/Files/FilePreviewColumn.swift
+++ b/Wired 3/Features/Files/FilePreviewColumn.swift
@@ -2,14 +2,13 @@ import SwiftUI
 
 struct FilePreviewColumn: View {
     let selectedItem: FileItem?
+    var syncPairStatusForItem: ((FileItem) -> SyncPairStatusDisplay)?
+    var syncPairExistsForItem: ((FileItem) -> Bool)?
+
     @Environment(\.colorScheme) private var colorScheme
 
-    private var platformBackgroundColor: Color {
-        #if os(macOS)
-        return Color(nsColor: .windowBackgroundColor)
-        #else
-        return Color(.secondarySystemBackground)
-        #endif
+    private var backgroundColor: Color {
+        colorScheme == .light ? Color.white : Color(nsColor: .windowBackgroundColor)
     }
 
     private let dateFormatter: DateFormatter = {
@@ -20,66 +19,266 @@ struct FilePreviewColumn: View {
     }()
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 10) {
+        ScrollView(.vertical, showsIndicators: false) {
             if let item = selectedItem {
-                HStack {
-                    Spacer()
-                    VStack(alignment: .center, spacing: 10) {
-                        FinderFileIconView(item: item, size: 128)
-
-                        Text(item.name.isEmpty ? item.path : item.name)
-                            .font(.subheadline)
-                            .fontWeight(.semibold)
-                            .lineLimit(1)
+                VStack(alignment: .leading, spacing: 0) {
+                    iconHeader(item)
+                    metaSection(item)
+                    if item.type == .sync {
+                        syncSection(item)
                     }
+                }
+                .padding(.vertical, 12)
+            } else {
+                VStack {
+                    Spacer(minLength: 60)
+                    Image(systemName: "rectangle.split.3x1")
+                        .font(.system(size: 28, weight: .ultraLight))
+                        .foregroundStyle(.tertiary)
+                    Text("No Selection")
+                        .font(.caption)
+                        .foregroundStyle(.tertiary)
+                        .padding(.top, 6)
                     Spacer()
                 }
-
-                Divider()
-
-                Group {
-                    infoRow("Type", item.type.description)
-                    infoRow("Size", sizeString(for: item))
-                    infoRow("Created", dateString(item.creationDate))
-                    infoRow("Modified", dateString(item.modificationDate))
-                    infoRow("Contains", containsString(for: item))
-                }
-            } else {
-                Text("Select a file or folder.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
+                .frame(maxWidth: .infinity)
             }
-
-            Spacer()
         }
-        .padding(10)
-        .background(colorScheme == .light ? Color.white : platformBackgroundColor)
+        .background(backgroundColor)
+    }
+
+    // MARK: - Icon + name header
+
+    private func iconHeader(_ item: FileItem) -> some View {
+        VStack(spacing: 8) {
+            FinderFileIconView(item: item, size: 72)
+                .shadow(color: .black.opacity(0.10), radius: 4, y: 2)
+
+            Text(item.name.isEmpty ? item.path : item.name)
+                .font(.subheadline).fontWeight(.semibold)
+                .multilineTextAlignment(.center)
+                .lineLimit(2)
+                .padding(.horizontal, 12)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 14)
+    }
+
+    // MARK: - Metadata section
+
+    private func metaSection(_ item: FileItem) -> some View {
+        previewCard {
+            metaRow("Type", item.type.description)
+            cardDivider
+            metaRow("Size", sizeString(for: item))
+            if let created = item.creationDate {
+                cardDivider
+                metaRow("Created", dateFormatter.string(from: created))
+            }
+            if let modified = item.modificationDate {
+                cardDivider
+                metaRow("Modified", dateFormatter.string(from: modified))
+            }
+            if item.type.isDirectoryLike {
+                cardDivider
+                metaRow("Contains", containsString(for: item))
+            }
+            if item.label != .none {
+                cardDivider
+                labelRow(item.label)
+            }
+        }
+    }
+
+    private func labelRow(_ label: FileLabelValue) -> some View {
+        HStack(alignment: .firstTextBaseline) {
+            Text("Label")
+                .font(.caption).foregroundStyle(.secondary)
+            Spacer()
+            HStack(spacing: 5) {
+                Circle()
+                    .fill(label.color)
+                    .frame(width: 8, height: 8)
+                Text(label.title)
+                    .font(.caption).fontWeight(.medium)
+                    .foregroundStyle(label.color)
+            }
+        }
+        .padding(.horizontal, 12).padding(.vertical, 6)
+    }
+
+    // MARK: - Sync section
+
+    private func syncSection(_ item: FileItem) -> some View {
+        let status = syncPairStatusForItem?(item) ?? .inactive
+        let pairExists = syncPairExistsForItem?(item) ?? false
+        let effectiveMode = SyncModeLabel.from(item.syncEffectiveMode)
+
+        return previewCard(title: "Sync Pair", icon: "arrow.2.circlepath") {
+            // Status row
+            HStack {
+                Text("Status")
+                    .font(.caption).foregroundStyle(.secondary)
+                Spacer()
+                syncStatusBadge(status)
+            }
+            .padding(.horizontal, 12).padding(.vertical, 6)
+
+            cardDivider
+
+            // Pair active row
+            HStack {
+                Text("Pair")
+                    .font(.caption).foregroundStyle(.secondary)
+                Spacer()
+                HStack(spacing: 5) {
+                    Circle()
+                        .fill(pairExists ? Color.green : Color.secondary.opacity(0.4))
+                        .frame(width: 6, height: 6)
+                    Text(pairExists ? "Active" : "Inactive")
+                        .font(.caption).fontWeight(.medium)
+                        .foregroundStyle(pairExists ? .primary : .secondary)
+                }
+            }
+            .padding(.horizontal, 12).padding(.vertical, 6)
+
+            cardDivider
+
+            // Effective mode row
+            HStack {
+                Text("Mode")
+                    .font(.caption).foregroundStyle(.secondary)
+                Spacer()
+                Label(effectiveMode.title, systemImage: effectiveMode.icon)
+                    .font(.caption).fontWeight(.medium)
+                    .foregroundStyle(.primary)
+                    .labelStyle(.titleAndIcon)
+            }
+            .padding(.horizontal, 12).padding(.vertical, 6)
+        }
     }
 
     @ViewBuilder
-    private func infoRow(_ title: String, _ value: String) -> some View {
-        HStack(alignment: .firstTextBaseline) {
-            Text(title)
-                .font(.caption)
+    private func syncStatusBadge(_ status: SyncPairStatusDisplay) -> some View {
+        let info = SyncStatusInfo.from(status)
+        HStack(spacing: 5) {
+            if info.spinning {
+                ProgressView()
+                    .scaleEffect(0.55)
+                    .frame(width: 10, height: 10)
+            } else {
+                Image(systemName: info.icon)
+                    .font(.caption2)
+                    .foregroundStyle(info.color)
+            }
+            Text(info.label)
+                .font(.caption).fontWeight(.medium)
+                .foregroundStyle(info.color)
+        }
+        .padding(.horizontal, 8).padding(.vertical, 3)
+        .background(info.color.opacity(0.10))
+        .clipShape(Capsule())
+    }
+
+    // MARK: - Card primitives
+
+    private func previewCard<Content: View>(
+        title: String? = nil,
+        icon: String? = nil,
+        @ViewBuilder content: () -> Content
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 0) {
+            if let title, let icon {
+                HStack(spacing: 5) {
+                    Image(systemName: icon)
+                        .font(.caption2).fontWeight(.semibold)
+                    Text(title)
+                        .font(.caption).fontWeight(.semibold)
+                }
                 .foregroundStyle(.secondary)
-                .frame(width: 70, alignment: .leading)
+                .padding(.horizontal, 12).padding(.top, 10).padding(.bottom, 5)
+            }
+            content()
+        }
+        .padding(.horizontal, 10)
+        .padding(.top, 8)
+    }
+
+    private var cardDivider: some View {
+        Divider().padding(.horizontal, 12)
+    }
+
+    private func metaRow(_ label: String, _ value: String) -> some View {
+        HStack(alignment: .firstTextBaseline) {
+            Text(label)
+                .font(.caption).foregroundStyle(.secondary)
+            Spacer()
             Text(value)
                 .font(.caption)
+                .multilineTextAlignment(.trailing)
                 .lineLimit(1)
-            Spacer()
         }
+        .padding(.horizontal, 12).padding(.vertical, 6)
+    }
+
+    // MARK: - Helpers
+
+    private func sizeString(for item: FileItem) -> String {
+        let total = item.dataSize + item.rsrcSize
+        guard total > 0 else { return "-" }
+        return ByteCountFormatter.string(fromByteCount: Int64(total), countStyle: .file)
     }
 
     private func containsString(for item: FileItem) -> String {
-        if item.type.isDirectoryLike {
-            guard item.hasDirectoryCount else { return "-" }
-            return item.directoryCount == 1 ? "1 item" : "\(item.directoryCount) items"
-        }
-        return "-"
+        guard item.hasDirectoryCount else { return "-" }
+        return item.directoryCount == 1 ? "1 item" : "\(item.directoryCount) items"
     }
+}
 
-    private func dateString(_ date: Date?) -> String {
-        guard let date else { return "-" }
-        return dateFormatter.string(from: date)
+// MARK: - Sync display helpers
+
+private struct SyncStatusInfo {
+    let label: String
+    let icon: String
+    let color: Color
+    let spinning: Bool
+
+    static func from(_ status: SyncPairStatusDisplay) -> SyncStatusInfo {
+        switch status {
+        case .hidden, .inactive:
+            return .init(label: "Inactive",     icon: "link.circle",                        color: .secondary, spinning: false)
+        case .checking:
+            return .init(label: "Checking…",    icon: "",                                   color: .secondary, spinning: true)
+        case .paused:
+            return .init(label: "Paused",       icon: "pause.circle.fill",                  color: .orange,    spinning: false)
+        case .connecting:
+            return .init(label: "Connecting…",  icon: "",                                   color: .blue,      spinning: true)
+        case .connected:
+            return .init(label: "Connected",    icon: "checkmark.circle.fill",              color: .green,     spinning: false)
+        case .syncing:
+            return .init(label: "Syncing…",     icon: "",                                   color: .blue,      spinning: true)
+        case .reconnecting:
+            return .init(label: "Reconnecting", icon: "",                                   color: .orange,    spinning: true)
+        case .error:
+            return .init(label: "Error",        icon: "exclamationmark.triangle.fill",      color: .red,       spinning: false)
+        }
+    }
+}
+
+private struct SyncModeLabel {
+    let title: String
+    let icon: String
+
+    static func from(_ mode: SyncModeValue) -> SyncModeLabel {
+        switch mode {
+        case .disabled:
+            return .init(title: "Disabled",         icon: "slash.circle")
+        case .serverToClient:
+            return .init(title: "Server → Client",  icon: "arrow.down.circle")
+        case .clientToServer:
+            return .init(title: "Client → Server",  icon: "arrow.up.circle")
+        case .bidirectional:
+            return .init(title: "Bidirectional",    icon: "arrow.2.circlepath")
+        }
     }
 }

--- a/Wired 3/Features/Files/FileServiceProtocol.swift
+++ b/Wired 3/Features/Files/FileServiceProtocol.swift
@@ -59,6 +59,18 @@ protocol FileServiceProtocol {
         connection: AsyncConnection
     ) async throws
 
+    func setFileComment(
+        path: String,
+        comment: String,
+        connection: AsyncConnection
+    ) async throws
+
+    func setFileLabel(
+        path: String,
+        label: FileLabelValue,
+        connection: AsyncConnection
+    ) async throws
+
     func setFilePermissions(
         path: String,
         permissions: DropboxPermissions,
@@ -204,6 +216,46 @@ final class FileService: FileServiceProtocol {
 
         message.addParameter(field: "wired.file.path", value: path)
         message.addParameter(field: "wired.file.type", value: type.rawValue)
+
+        let response = try await connection.sendAsync(message)
+
+        if response?.name == "wired.error" {
+            throw WiredError(message: response!)
+        }
+    }
+
+    func setFileComment(
+        path: String,
+        comment: String,
+        connection: AsyncConnection
+    ) async throws {
+        let message = P7Message(
+            withName: "wired.file.set_comment",
+            spec: spec
+        )
+
+        message.addParameter(field: "wired.file.path", value: path)
+        message.addParameter(field: "wired.file.comment", value: comment)
+
+        let response = try await connection.sendAsync(message)
+
+        if response?.name == "wired.error" {
+            throw WiredError(message: response!)
+        }
+    }
+
+    func setFileLabel(
+        path: String,
+        label: FileLabelValue,
+        connection: AsyncConnection
+    ) async throws {
+        let message = P7Message(
+            withName: "wired.file.set_label",
+            spec: spec
+        )
+
+        message.addParameter(field: "wired.file.path", value: path)
+        message.addParameter(field: "wired.file.label", value: label.rawValue)
 
         let response = try await connection.sendAsync(message)
 

--- a/Wired 3/Features/Files/FilesColumnsView.swift
+++ b/Wired 3/Features/Files/FilesColumnsView.swift
@@ -54,8 +54,12 @@ struct FilesColumnsView: View {
                         ColumnResizeHandle(width: binding(for: column.id))
                     }
 
-                    FilePreviewColumn(selectedItem: selectedItem)
-                        .frame(width: previewWidth)
+                    FilePreviewColumn(
+                        selectedItem: selectedItem,
+                        syncPairStatusForItem: syncPairStatusForItem,
+                        syncPairExistsForItem: syncPairExistsForItem
+                    )
+                    .frame(width: previewWidth)
 
                     ColumnResizeHandle(width: $previewWidth)
                 }

--- a/Wired 3/Features/Files/FilesColumnsView.swift
+++ b/Wired 3/Features/Files/FilesColumnsView.swift
@@ -28,6 +28,8 @@ struct FilesColumnsView: View {
     let canDeleteForItem: (FileItem) -> Bool
     let canUploadToDirectory: (FileItem) -> Bool
     let canCreateFolderInDirectory: (FileItem) -> Bool
+    let canSetLabel: Bool
+    let onRequestSetLabel: ([FileItem], FileLabelValue) -> Void
     let onUploadURLs: ([URL], FileItem) -> Void
     let onMoveRemoteItem: (_ sourcePath: String, _ destinationDirectory: FileItem) async throws -> Void
 
@@ -134,8 +136,16 @@ struct FilesColumnsView: View {
             canDeleteForItem: canDeleteForItem,
             canUploadToDirectory: canUploadToDirectory,
             canCreateFolderInDirectory: canCreateFolderInDirectory,
+            canSetLabel: canSetLabel,
+            onRequestSetLabel: onRequestSetLabel,
             savedScrollOffset: filesViewModel.columnScrollOffsets[column.id] ?? 0,
-            onScrollOffsetChange: { filesViewModel.columnScrollOffsets[column.id] = $0 }
+            onScrollOffsetChange: { filesViewModel.columnScrollOffsets[column.id] = $0 },
+            onDesiredWidthChange: { desired in
+                let clamped = min(max(desired, 180), 620)
+                if abs((columnWidths[column.id] ?? 240) - clamped) > 2 {
+                    columnWidths[column.id] = clamped
+                }
+            }
         )
         .frame(width: width(for: column))
         .background(Color.clear)

--- a/Wired 3/Features/Files/FilesTreeView.swift
+++ b/Wired 3/Features/Files/FilesTreeView.swift
@@ -29,6 +29,8 @@ struct FilesTreeView: View {
     let canDeleteForItem: (FileItem) -> Bool
     let canUploadToDirectory: (FileItem) -> Bool
     let canCreateFolderInDirectory: (FileItem) -> Bool
+    let canSetLabel: Bool
+    let onRequestSetLabel: ([FileItem], FileLabelValue) -> Void
     let onUploadURLs: ([URL], FileItem) -> Void
     let onMoveRemoteItem: (_ sourcePath: String, _ destinationDirectory: FileItem) async throws -> Void
     @State private var finderDropTargetPath: String?
@@ -128,6 +130,8 @@ struct FilesTreeView: View {
             canDeleteForItem: canDeleteForItem,
             canUploadToDirectory: canUploadToDirectory,
             canCreateFolderInDirectory: canCreateFolderInDirectory,
+            canSetLabel: canSetLabel,
+            onRequestSetLabel: onRequestSetLabel,
             savedScrollOffset: filesViewModel.treeScrollOffset,
             onScrollOffsetChange: { filesViewModel.treeScrollOffset = $0 }
         )

--- a/Wired 3/Features/Files/FilesView.swift
+++ b/Wired 3/Features/Files/FilesView.swift
@@ -561,6 +561,18 @@ struct FilesView: View {
 #endif
     }
 
+    private func setLabel(_ label: FileLabelValue, on items: [FileItem]) {
+        Task {
+            for item in items {
+                do {
+                    try await filesViewModel.setFileLabel(path: item.path, label: label)
+                } catch {
+                    filesViewModel.error = error
+                }
+            }
+        }
+    }
+
     private func syncNow(for directory: FileItem) {
 #if os(macOS)
         let serverURL = currentSyncServerURL
@@ -839,6 +851,10 @@ struct FilesView: View {
             canCreateFolderInDirectory: { directory in
                 canCreateFolder(in: directory)
             },
+            canSetLabel: runtime.hasPrivilege("wired.account.file.set_label"),
+            onRequestSetLabel: { items, label in
+                setLabel(label, on: items)
+            },
             onUploadURLs: { urls, target in
                 upload(urls: urls, to: target)
             },
@@ -917,6 +933,10 @@ struct FilesView: View {
             },
             canCreateFolderInDirectory: { directory in
                 canCreateFolder(in: directory)
+            },
+            canSetLabel: runtime.hasPrivilege("wired.account.file.set_label"),
+            onRequestSetLabel: { items, label in
+                setLabel(label, on: items)
             },
             onUploadURLs: { urls, target in
                 upload(urls: urls, to: target)

--- a/Wired 3/Features/Files/FilesViewModel.swift
+++ b/Wired 3/Features/Files/FilesViewModel.swift
@@ -685,6 +685,28 @@ final class FilesViewModel: ObservableObject {
     }
 
     @MainActor
+    func setFileComment(path: String, comment: String) async throws {
+        guard let connection = runtime?.connection as? AsyncConnection,
+              let fileService else { return }
+
+        try await withFileNetworkActivity {
+            try await fileService.setFileComment(path: path, comment: comment, connection: connection)
+        }
+        await reloadAll()
+    }
+
+    @MainActor
+    func setFileLabel(path: String, label: FileLabelValue) async throws {
+        guard let connection = runtime?.connection as? AsyncConnection,
+              let fileService else { return }
+
+        try await withFileNetworkActivity {
+            try await fileService.setFileLabel(path: path, label: label, connection: connection)
+        }
+        await reloadAll()
+    }
+
+    @MainActor
     func setFilePermissions(path: String, permissions: DropboxPermissions) async throws {
         guard let connection = runtime?.connection as? AsyncConnection,
               let fileService else { return }

--- a/Wired 3/Features/Files/RemoteItemIconSupport.swift
+++ b/Wired 3/Features/Files/RemoteItemIconSupport.swift
@@ -17,26 +17,27 @@ private final class RemoteFolderIconCache {
 
     private init() {}
 
-    func icon(for kind: RemoteFolderIconKind, size: CGFloat) -> NSImage {
+    func icon(for kind: RemoteFolderIconKind, label: FileLabelValue, size: CGFloat) -> NSImage {
         let normalizedSize = max(1, Int(round(size)))
-        let key = "\(kind.rawValue)-\(normalizedSize)"
+        let key = "\(kind.rawValue)-\(label.rawValue)-\(normalizedSize)"
         if let cached = cache[key] {
             return cached
         }
 
-        let icon = makeIcon(for: kind, size: CGFloat(normalizedSize))
+        let icon = makeIcon(for: kind, label: label, size: CGFloat(normalizedSize))
         cache[key] = icon
         return icon
     }
 
-    private func makeIcon(for kind: RemoteFolderIconKind, size: CGFloat) -> NSImage {
+    private func makeIcon(for kind: RemoteFolderIconKind, label: FileLabelValue, size: CGFloat) -> NSImage {
         let frame = NSSize(width: size, height: size)
-        let base = (NSWorkspace.shared.icon(for: .folder).copy() as? NSImage)
-            ?? NSWorkspace.shared.icon(for: .folder)
+        let base = NSWorkspace.shared.icon(for: .folder)
         base.size = frame
 
+        let folderBase = tint(baseFolderIcon: base, with: label)
+
         guard kind != .directory else {
-            return base
+            return folderBase
         }
 
         let badgeName: String = {
@@ -48,7 +49,7 @@ private final class RemoteFolderIconCache {
             }
         }()
         guard let badgeImage = loadBadgeImage(named: badgeName)?.copy() as? NSImage else {
-            return base
+            return folderBase
         }
         let badgeScale: CGFloat = 1.60
         let badgeSize = NSSize(width: frame.width * badgeScale, height: frame.height * badgeScale)
@@ -62,10 +63,56 @@ private final class RemoteFolderIconCache {
 
         let composed = NSImage(size: frame)
         composed.lockFocus()
-        base.draw(in: NSRect(origin: .zero, size: frame))
+        folderBase.draw(in: NSRect(origin: .zero, size: frame))
         badgeImage.draw(in: badgeRect)
         composed.unlockFocus()
         return composed
+    }
+
+    /// Tints the Finder native folder icon with the label color.
+    /// Pipeline:
+    ///   1. Desaturate to neutral gray (removes blue bias from the Finder icon).
+    ///   2. Paint the label color at high opacity via .sourceAtop (respects icon alpha,
+    ///      no background bleed). The residual ~20 % gray provides the 3D depth.
+    ///   3. Restore highlights by overlaying the original icon at low opacity with
+    ///      .luminosity, so the bright specular areas stay crisp.
+    private func tint(baseFolderIcon: NSImage, with label: FileLabelValue) -> NSImage {
+        guard label != .none else { return baseFolderIcon }
+
+        let size = baseFolderIcon.size
+        let rect = NSRect(origin: .zero, size: size)
+
+        // Step 1 — desaturate: draw a gray mask shaped to the icon via .destinationIn,
+        // then composite it onto the original with .saturation (S→0, keeps H+L).
+        let grayMask = NSImage(size: size)
+        grayMask.lockFocus()
+        NSColor(calibratedWhite: 0.5, alpha: 1.0).setFill()
+        rect.fill()
+        baseFolderIcon.draw(in: rect, from: .zero, operation: .destinationIn, fraction: 1.0)
+        grayMask.unlockFocus()
+
+        let grayIcon = NSImage(size: size)
+        grayIcon.lockFocus()
+        baseFolderIcon.draw(in: rect, from: .zero, operation: .sourceOver, fraction: 1.0)
+        grayMask.draw(in: rect, from: .zero, operation: .saturation, fraction: 1.0)
+        grayIcon.unlockFocus()
+
+        guard label != .gray else { return grayIcon }
+
+        // Step 2 — colorize: paint the vivid label color at 80 % opacity.
+        // .sourceAtop clips the fill to existing pixels (no halo around the icon).
+        let result = NSImage(size: size)
+        result.lockFocus()
+        grayIcon.draw(in: rect, from: .zero, operation: .sourceOver, fraction: 1.0)
+        label.vividColor.withAlphaComponent(0.80).setFill()
+        rect.fill(using: .sourceAtop)
+
+        // Step 3 — restore highlights: the original icon at 25 % with .luminosity
+        // brings back the specular white areas without re-introducing the blue cast.
+        baseFolderIcon.draw(in: rect, from: .zero, operation: .luminosity, fraction: 0.25)
+        result.unlockFocus()
+
+        return result
     }
 
     private func loadBadgeImage(named name: String) -> NSImage? {
@@ -88,17 +135,35 @@ func remoteItemIconImage(for item: FileItem, size: CGFloat) -> NSImage {
         let contentType = ext.isEmpty ? UTType.data : (UTType(filenameExtension: ext) ?? .data)
         icon = NSWorkspace.shared.icon(for: contentType)
     case .directory:
-        icon = RemoteFolderIconCache.shared.icon(for: .directory, size: size)
+        icon = RemoteFolderIconCache.shared.icon(for: .directory, label: item.label, size: size)
     case .uploads:
-        icon = RemoteFolderIconCache.shared.icon(for: .uploads, size: size)
+        icon = RemoteFolderIconCache.shared.icon(for: .uploads, label: item.label, size: size)
     case .dropbox:
-        icon = RemoteFolderIconCache.shared.icon(for: .dropbox, size: size)
+        icon = RemoteFolderIconCache.shared.icon(for: .dropbox, label: item.label, size: size)
     case .sync:
-        icon = RemoteFolderIconCache.shared.icon(for: .sync, size: size)
+        icon = RemoteFolderIconCache.shared.icon(for: .sync, label: item.label, size: size)
     }
 
     let copy = (icon.copy() as? NSImage) ?? icon
     copy.size = NSSize(width: size, height: size)
     return copy
+}
+
+private extension FileLabelValue {
+    /// Fully saturated RGB colors used for folder tinting.
+    /// Using explicit values instead of NSColor.system* to avoid adaptive/dynamic
+    /// colors whose actual RGB can vary with appearance and be less saturated.
+    var vividColor: NSColor {
+        switch self {
+        case .none:  return .secondaryLabelColor
+        case .red:   return NSColor(calibratedRed: 0.92, green: 0.08, blue: 0.10, alpha: 1)
+        case .orange: return NSColor(calibratedRed: 1.00, green: 0.42, blue: 0.00, alpha: 1)
+        case .yellow: return NSColor(calibratedRed: 1.00, green: 0.78, blue: 0.00, alpha: 1)
+        case .green:  return NSColor(calibratedRed: 0.10, green: 0.72, blue: 0.18, alpha: 1)
+        case .blue:   return NSColor(calibratedRed: 0.08, green: 0.40, blue: 0.95, alpha: 1)
+        case .purple: return NSColor(calibratedRed: 0.55, green: 0.18, blue: 0.88, alpha: 1)
+        case .gray:   return NSColor(calibratedWhite: 0.50, alpha: 1)
+        }
+    }
 }
 #endif

--- a/Wired 3/Features/Messages/Views/MessageConversationDetailView.swift
+++ b/Wired 3/Features/Messages/Views/MessageConversationDetailView.swift
@@ -4,15 +4,26 @@
 //
 
 import SwiftUI
+import UniformTypeIdentifiers
+#if os(macOS)
+import AppKit
+#endif
 
 struct MessageConversationDetailView: View {
     @Environment(ConnectionRuntime.self) private var runtime
 
     let conversation: MessageConversation
     var searchText: String = ""
+#if os(macOS)
+    @State private var isAttachmentDropTargeted = false
+#endif
 
     private var inputText: String {
         runtime.messageDrafts[conversation.id] ?? ""
+    }
+
+    private var draftAttachments: [ChatDraftAttachment] {
+        runtime.messageDraftAttachments[conversation.id] ?? []
     }
 
     private var inputTextBinding: Binding<String> {
@@ -23,10 +34,11 @@ struct MessageConversationDetailView: View {
     }
 
     private var composerOverlayInset: CGFloat {
+        let attachmentInset: CGFloat = draftAttachments.isEmpty ? 0 : 42
         #if os(macOS)
-        58
+        return 58 + attachmentInset
         #else
-        76
+        return 76 + attachmentInset
         #endif
     }
 
@@ -40,6 +52,9 @@ struct MessageConversationDetailView: View {
                 return "No broadcast permission"
             }
             return "User unavailable"
+        }
+        if !draftAttachments.isEmpty {
+            return conversation.kind == .broadcast ? "Broadcast message required…" : "Add a message or press Return to send…"
         }
         if conversation.kind == .broadcast {
             return "Broadcast to all online users…"
@@ -56,44 +71,117 @@ struct MessageConversationDetailView: View {
             )
             .environment(runtime)
 
-            HStack(alignment: .top, spacing: 0) {
-                ConversationComposer(
-                    text: inputTextBinding,
-                    placeholder: placeholder,
-                    isEnabled: canSend,
-                    onSend: { text in
-                        do {
-                            switch conversation.kind {
-                            case .direct:
-                                try await runtime.sendPrivateMessage(text, in: conversation)
-                            case .broadcast:
-                                try await runtime.sendBroadcastMessage(text)
+            VStack(alignment: .leading, spacing: 6) {
+                if !draftAttachments.isEmpty {
+                    ScrollView(.horizontal, showsIndicators: false) {
+                        HStack(spacing: 8) {
+                            ForEach(draftAttachments) { attachment in
+                                ChatDraftAttachmentChipView(attachment: attachment) {
+                                    runtime.removeMessageDraftAttachment(attachment, for: conversation.id)
+                                }
                             }
-                        } catch {
-                            runtime.lastError = error
                         }
+                        .padding(.leading, 10)
+                        .padding(.trailing, 8)
                     }
-                )
-#if os(macOS)
-                Button {
-                        NSApp.orderFrontCharacterPalette(nil)
-                } label: {
-                    Image(systemName: "face.smiling")
-                        .font(.title3)
                 }
-                .foregroundColor(.gray)
-                .buttonStyle(.plain)
-                .padding(.top, 8)
-                .padding(.trailing, 8)
+
+                HStack(alignment: .top, spacing: 0) {
+                    ConversationComposer(
+                        text: inputTextBinding,
+                        placeholder: placeholder,
+                        isEnabled: canSend,
+                        allowsEmptySubmit: conversation.kind == .direct && !draftAttachments.isEmpty,
+                        onSend: { text in
+                            do {
+                                switch conversation.kind {
+                                case .direct:
+                                    try await runtime.sendPrivateMessage(text, in: conversation, attachments: draftAttachments)
+                                    runtime.clearMessageDraftAttachments(for: conversation.id)
+                                case .broadcast:
+                                    try await runtime.sendBroadcastMessage(text)
+                                }
+                            } catch {
+                                runtime.messageDrafts[conversation.id] = text
+                                runtime.lastError = error
+                            }
+                        }
+                    )
+                    .frame(maxWidth: .infinity, alignment: .leading)
+#if os(macOS)
+                    Button {
+                        NSApp.orderFrontCharacterPalette(nil)
+                    } label: {
+                        Image(systemName: "face.smiling")
+                            .font(.title3)
+                    }
+                    .foregroundColor(.gray)
+                    .buttonStyle(.plain)
+                    .padding(.top, 8)
+                    .padding(.trailing, 8)
 #endif
+                }
             }
             .backgroundEdgeFade(top: 0, bottom: 60)
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomLeading)
         }
         .contentMargins(.bottom, 15, for: .scrollIndicators)
         .background(.background)
+#if os(macOS)
+        .overlay {
+            RoundedRectangle(cornerRadius: 18, style: .continuous)
+                .stroke(Color.accentColor.opacity(isAttachmentDropTargeted ? 0.9 : 0), lineWidth: 4)
+                .background(
+                    RoundedRectangle(cornerRadius: 18, style: .continuous)
+                        .fill(Color.accentColor.opacity(isAttachmentDropTargeted ? 0.08 : 0))
+                )
+                .padding(8)
+                .allowsHitTesting(false)
+        }
+        .onDrop(of: [UTType.fileURL.identifier], isTargeted: $isAttachmentDropTargeted) { providers in
+            handleFileDrop(providers: providers)
+        }
+#endif
         .onAppear {
             runtime.resetUnreads(conversation)
         }
     }
+
+#if os(macOS)
+    private func handleFileDrop(providers: [NSItemProvider]) -> Bool {
+        guard conversation.kind == .direct, canSend else { return false }
+
+        let fileProviders = providers.filter {
+            $0.hasItemConformingToTypeIdentifier(UTType.fileURL.identifier)
+        }
+
+        guard !fileProviders.isEmpty else { return false }
+
+        for provider in fileProviders {
+            provider.loadDataRepresentation(forTypeIdentifier: UTType.fileURL.identifier) { data, error in
+                if let error {
+                    Task { @MainActor in
+                        runtime.lastError = error
+                    }
+                    return
+                }
+
+                guard let data,
+                      let fileURL = URL(dataRepresentation: data, relativeTo: nil) else {
+                    return
+                }
+
+                Task { @MainActor in
+                    do {
+                        try runtime.addMessageDraftAttachment(fileURL, for: conversation.id)
+                    } catch {
+                        runtime.lastError = error
+                    }
+                }
+            }
+        }
+
+        return true
+    }
+#endif
 }

--- a/Wired 3/Features/Messages/Views/MessageConversationMessagesView.swift
+++ b/Wired 3/Features/Messages/Views/MessageConversationMessagesView.swift
@@ -16,6 +16,10 @@ struct MessageConversationMessagesView: View {
     @State private var revealNewMessage = true
     @State private var displayedMessageCount: Int = 100
     @State private var isLoadingMore = false
+    @State private var selectedImageSource: ChatImageQuickLookSource?
+#if os(macOS)
+    @State private var quickLookController = ChatImageQuickLookController()
+#endif
     var bottomOverlayInset: CGFloat = 0
 
     private let bottomAnchorID = "message-conversation-bottom-anchor"
@@ -111,6 +115,7 @@ struct MessageConversationMessagesView: View {
         }
         .onChange(of: conversation.id) {
             displayedMessageCount = maxDisplayedMessages
+            selectedImageSource = nil
         }
         .onChange(of: maxDisplayedMessages) { _, newMax in
             if displayedMessageCount < newMax {
@@ -137,7 +142,15 @@ struct MessageConversationMessagesView: View {
                                 currentUserID: runtime.userID,
                                 showNickname: showNickname,
                                 showAvatar: showAvatar,
-                                isGroupedWithNext: isGroupedWithNext
+                                isGroupedWithNext: isGroupedWithNext,
+                                selectedImageSource: selectedImageSource,
+                                onSelectImage: { source in
+                                    selectedImageSource = source
+                                },
+                                onOpenQuickLook: { source in
+                                    selectedImageSource = source
+                                    openQuickLook(for: source)
+                                }
                             )
                                 .scaleEffect(message.id == animatedNewMessageID ? (revealNewMessage ? 1 : 0.94) : 1)
                                 .opacity(message.id == animatedNewMessageID ? (revealNewMessage ? 1 : 0) : 1)
@@ -153,6 +166,11 @@ struct MessageConversationMessagesView: View {
             .background(.clear)
             .textSelection(.enabled)
             .frame(maxHeight: .infinity)
+#if os(macOS)
+            .chatQuickLookSpaceMonitor(isEnabled: selectedImageSource != nil) {
+                openSelectedImageQuickLook()
+            }
+#endif
             .onChange(of: conversation.messages.last?.id) {
                 guard let lastMessage = conversation.messages.last else { return }
                 let isVisible = !isSearching || lastMessage.matchesSearch(normalizedSearchText)
@@ -262,6 +280,32 @@ struct MessageConversationMessagesView: View {
             isLoadingMore = false
         }
     }
+
+    private func openSelectedImageQuickLook() {
+#if os(macOS)
+        guard let selectedImageSource else { return }
+        openQuickLook(for: selectedImageSource)
+#endif
+    }
+
+    private func openQuickLook(for source: ChatImageQuickLookSource) {
+#if os(macOS)
+        Task {
+            do {
+                let localURL = try await source.quickLookURL(connectionID: runtime.id, runtime: runtime)
+                await MainActor.run {
+                    quickLookController.present(localURL: localURL, title: source.title)
+                }
+            } catch {
+                await MainActor.run {
+                    runtime.lastError = error
+                }
+            }
+        }
+        #else
+        _ = source
+        #endif
+    }
 }
 
 private struct MessageBubbleRow: View {
@@ -272,6 +316,9 @@ private struct MessageBubbleRow: View {
     let showNickname: Bool
     let showAvatar: Bool
     let isGroupedWithNext: Bool
+    var selectedImageSource: ChatImageQuickLookSource?
+    var onSelectImage: ((ChatImageQuickLookSource) -> Void)?
+    var onOpenQuickLook: ((ChatImageQuickLookSource) -> Void)?
 
     private var primaryImageURL: URL? {
         message.cachedPrimaryHTTPImageURL
@@ -378,18 +425,34 @@ private struct MessageBubbleRow: View {
             }
 
             if let primaryImageURL {
+                let source = ChatImageQuickLookSource.remote(primaryImageURL)
                 ChatRemoteImageBubbleView(
                     url: primaryImageURL,
                     isFromYou: isFromYou,
-                    showsTail: imageAttachments.isEmpty && fileAttachments.isEmpty && !isGroupedWithNext
+                    showsTail: imageAttachments.isEmpty && fileAttachments.isEmpty && !isGroupedWithNext,
+                    isSelected: selectedImageSource?.selectionID == source.selectionID,
+                    onSelect: {
+                        onSelectImage?(source)
+                    },
+                    onOpenQuickLook: {
+                        onOpenQuickLook?(source)
+                    }
                 )
             }
 
             ForEach(Array(imageAttachments.enumerated()), id: \.element.id) { index, attachment in
+                let source = ChatImageQuickLookSource.attachment(attachment)
                 ChatAttachmentImageBubbleView(
                     attachment: attachment,
                     isFromYou: isFromYou,
-                    showsTail: index == imageAttachments.count - 1 && fileAttachments.isEmpty && !isGroupedWithNext
+                    showsTail: index == imageAttachments.count - 1 && fileAttachments.isEmpty && !isGroupedWithNext,
+                    isSelected: selectedImageSource?.selectionID == source.selectionID,
+                    onSelect: {
+                        onSelectImage?(source)
+                    },
+                    onOpenQuickLook: {
+                        onOpenQuickLook?(source)
+                    }
                 )
             }
 

--- a/Wired 3/Features/Messages/Views/MessageConversationMessagesView.swift
+++ b/Wired 3/Features/Messages/Views/MessageConversationMessagesView.swift
@@ -352,6 +352,7 @@ private struct MessageBubbleRow: View {
         }
         .listRowSeparator(.hidden)
         .listRowInsets(EdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0))
+        .padding(.horizontal, 10)
     }
 
     @ViewBuilder

--- a/Wired 3/Features/Messages/Views/MessageConversationMessagesView.swift
+++ b/Wired 3/Features/Messages/Views/MessageConversationMessagesView.swift
@@ -277,6 +277,14 @@ private struct MessageBubbleRow: View {
         message.cachedPrimaryHTTPImageURL
     }
 
+    private var imageAttachments: [ChatAttachmentDescriptor] {
+        message.attachments.filter(\.isImage)
+    }
+
+    private var fileAttachments: [ChatAttachmentDescriptor] {
+        message.attachments.filter { !$0.isImage }
+    }
+
     private var trimmedMessageText: String {
         message.text.trimmingCharacters(in: .whitespacesAndNewlines)
     }
@@ -287,7 +295,7 @@ private struct MessageBubbleRow: View {
     }
 
     private var shouldShowTextBubble: Bool {
-        !isImageOnlyMessage
+        !trimmedMessageText.isEmpty && !isImageOnlyMessage
     }
 
     private var isEmojiOnlyMessage: Bool {
@@ -357,7 +365,7 @@ private struct MessageBubbleRow: View {
                 Text(message.text.attributedWithDetectedLinks(linkColor: linkColor))
                     .messageBubbleStyle(
                         isFromYou: isFromYou,
-                        showsTail: primaryImageURL == nil && !isGroupedWithNext
+                        showsTail: primaryImageURL == nil && imageAttachments.isEmpty && fileAttachments.isEmpty && !isGroupedWithNext
                     )
                     .containerRelativeFrame(
                         .horizontal,
@@ -372,7 +380,23 @@ private struct MessageBubbleRow: View {
                 ChatRemoteImageBubbleView(
                     url: primaryImageURL,
                     isFromYou: isFromYou,
-                    showsTail: !isGroupedWithNext
+                    showsTail: imageAttachments.isEmpty && fileAttachments.isEmpty && !isGroupedWithNext
+                )
+            }
+
+            ForEach(Array(imageAttachments.enumerated()), id: \.element.id) { index, attachment in
+                ChatAttachmentImageBubbleView(
+                    attachment: attachment,
+                    isFromYou: isFromYou,
+                    showsTail: index == imageAttachments.count - 1 && fileAttachments.isEmpty && !isGroupedWithNext
+                )
+            }
+
+            ForEach(Array(fileAttachments.enumerated()), id: \.element.id) { index, attachment in
+                ChatAttachmentFileBubbleView(
+                    attachment: attachment,
+                    isFromYou: isFromYou,
+                    showsTail: index == fileAttachments.count - 1 && !isGroupedWithNext
                 )
             }
         }

--- a/Wired 3/Models/BoardPost.swift
+++ b/Wired 3/Models/BoardPost.swift
@@ -43,6 +43,7 @@ final class BoardPost: Identifiable {
     var isOwn: Bool
     var isUnread: Bool = false
     var isThreadBody: Bool = false
+    var attachments: [ChatAttachmentDescriptor]
     var reactions: [BoardReactionSummary] = []
     var reactionsLoaded: Bool = false
     /// Emojis that arrived from other users and haven't been animated yet (cleared after ~0.8 s).
@@ -55,7 +56,8 @@ final class BoardPost: Identifiable {
          postDate: Date,
          icon: Data? = nil,
          isOwn: Bool = false,
-         isThreadBody: Bool = false) {
+         isThreadBody: Bool = false,
+         attachments: [ChatAttachmentDescriptor] = []) {
         self.uuid       = uuid
         self.threadUUID = threadUUID
         self.text       = text
@@ -64,5 +66,6 @@ final class BoardPost: Identifiable {
         self.icon       = icon
         self.isOwn      = isOwn
         self.isThreadBody = isThreadBody
+        self.attachments = attachments
     }
 }

--- a/Wired 3/Models/ChatAttachment.swift
+++ b/Wired 3/Models/ChatAttachment.swift
@@ -1,0 +1,135 @@
+//
+//  ChatAttachment.swift
+//  Wired 3
+//
+
+import Foundation
+import UniformTypeIdentifiers
+import WiredSwift
+
+struct ChatAttachmentDescriptor: Codable, Hashable, Identifiable {
+    let id: String
+    let name: String
+    let mediaType: String
+    let size: UInt64
+    let sha256: String
+    let inlinePreview: Bool
+    let width: UInt32?
+    let height: UInt32?
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case name
+        case mediaType = "media_type"
+        case size
+        case sha256
+        case inlinePreview = "inline_preview"
+        case width
+        case height
+    }
+
+    var isImage: Bool {
+        mediaType.lowercased().hasPrefix("image/")
+    }
+
+    var fileSizeDescription: String {
+        byteCountFormatter.string(fromByteCount: Int64(size))
+    }
+
+    var preferredFilenameExtension: String? {
+        URL(fileURLWithPath: name).pathExtension.nilIfEmpty
+            ?? UTType(mimeType: mediaType)?.preferredFilenameExtension
+    }
+
+    static func descriptors(from message: P7Message) -> [ChatAttachmentDescriptor] {
+        let entries = message.stringList(forField: "wired.attachment.descriptors") ?? []
+        let decoder = JSONDecoder()
+        return entries.compactMap { entry in
+            guard let data = entry.data(using: .utf8) else { return nil }
+            return try? decoder.decode(ChatAttachmentDescriptor.self, from: data)
+        }
+    }
+}
+
+struct ChatDraftAttachment: Equatable, Identifiable {
+    static let maxSizeBytes: UInt64 = 16 * 1_024 * 1_024
+    static let maxAttachmentsPerMessage = 8
+    static let maxTotalSizeBytes: UInt64 = 32 * 1_024 * 1_024
+
+    let id = UUID()
+    let fileURL: URL
+    let fileName: String
+    let mediaType: String
+    let size: UInt64
+
+    init(fileURL: URL) throws {
+        let normalizedURL = fileURL.standardizedFileURL
+        let values = try normalizedURL.resourceValues(forKeys: [
+            .isRegularFileKey,
+            .fileSizeKey,
+            .contentTypeKey,
+            .nameKey
+        ])
+
+        guard values.isRegularFile == true else {
+            throw WiredError(withTitle: "Attachment", message: "Only regular files can be attached to a chat message.")
+        }
+
+        self.fileURL = normalizedURL
+        self.fileName = values.name ?? normalizedURL.lastPathComponent
+        self.size = UInt64(max(values.fileSize ?? 0, 0))
+
+        guard size > 0 else {
+            throw WiredError(withTitle: "Attachment", message: "Empty files cannot be attached to a chat message.")
+        }
+
+        guard size <= Self.maxSizeBytes else {
+            throw WiredError(
+                withTitle: "Attachment",
+                message: "This file is too large. Chat attachments are currently limited to \(byteCountFormatter.string(fromByteCount: Int64(Self.maxSizeBytes)))."
+            )
+        }
+
+        if let type = values.contentType {
+            self.mediaType = type.preferredMIMEType ?? "application/octet-stream"
+        } else if let type = UTType(filenameExtension: normalizedURL.pathExtension) {
+            self.mediaType = type.preferredMIMEType ?? "application/octet-stream"
+        } else {
+            self.mediaType = "application/octet-stream"
+        }
+    }
+
+    var fileSizeDescription: String {
+        byteCountFormatter.string(fromByteCount: Int64(size))
+    }
+
+    var isImage: Bool {
+        mediaType.lowercased().hasPrefix("image/")
+    }
+
+    static func validateDraftCollection(_ attachments: [ChatDraftAttachment]) throws {
+        guard attachments.count <= Self.maxAttachmentsPerMessage else {
+            throw WiredError(
+                withTitle: "Attachment",
+                message: "You can attach at most \(Self.maxAttachmentsPerMessage) files to a chat message."
+            )
+        }
+
+        let totalSize = attachments.reduce(UInt64(0)) { partialResult, attachment in
+            partialResult + attachment.size
+        }
+
+        guard totalSize <= Self.maxTotalSizeBytes else {
+            throw WiredError(
+                withTitle: "Attachment",
+                message: "These attachments are too large together. Chat attachments are currently limited to \(byteCountFormatter.string(fromByteCount: Int64(Self.maxTotalSizeBytes))) per message."
+            )
+        }
+    }
+}
+
+private extension String {
+    var nilIfEmpty: String? {
+        isEmpty ? nil : self
+    }
+}

--- a/Wired 3/Models/ChatAttachment.swift
+++ b/Wired 3/Models/ChatAttachment.swift
@@ -221,7 +221,8 @@ enum ComposerAttachmentItem: Identifiable, Equatable {
         guard totalSize <= ChatDraftAttachment.maxTotalSizeBytes else {
             throw WiredError(
                 withTitle: "Attachment",
-                message: "These attachments are too large together. Attachments are currently limited to \(byteCountFormatter.string(fromByteCount: Int64(ChatDraftAttachment.maxTotalSizeBytes))) per message."
+                message: "These attachments are too large together. Attachments are currently limited to " +
+                    "\(byteCountFormatter.string(fromByteCount: Int64(ChatDraftAttachment.maxTotalSizeBytes))) per message."
             )
         }
     }

--- a/Wired 3/Models/ChatAttachment.swift
+++ b/Wired 3/Models/ChatAttachment.swift
@@ -128,6 +128,105 @@ struct ChatDraftAttachment: Equatable, Identifiable {
     }
 }
 
+enum ComposerAttachmentItem: Identifiable, Equatable {
+    case local(ChatDraftAttachment)
+    case remote(ChatAttachmentDescriptor)
+
+    var id: String {
+        switch self {
+        case .local(let attachment):
+            return "local:\(attachment.id.uuidString.lowercased())"
+        case .remote(let descriptor):
+            return "remote:\(descriptor.id.lowercased())"
+        }
+    }
+
+    var fileName: String {
+        switch self {
+        case .local(let attachment):
+            return attachment.fileName
+        case .remote(let descriptor):
+            return descriptor.name
+        }
+    }
+
+    var mediaType: String {
+        switch self {
+        case .local(let attachment):
+            return attachment.mediaType
+        case .remote(let descriptor):
+            return descriptor.mediaType
+        }
+    }
+
+    var size: UInt64 {
+        switch self {
+        case .local(let attachment):
+            return attachment.size
+        case .remote(let descriptor):
+            return descriptor.size
+        }
+    }
+
+    var fileSizeDescription: String {
+        byteCountFormatter.string(fromByteCount: Int64(size))
+    }
+
+    var isImage: Bool {
+        mediaType.lowercased().hasPrefix("image/")
+    }
+
+    var descriptor: ChatAttachmentDescriptor? {
+        if case .remote(let descriptor) = self {
+            return descriptor
+        }
+        return nil
+    }
+
+    var draftAttachment: ChatDraftAttachment? {
+        if case .local(let attachment) = self {
+            return attachment
+        }
+        return nil
+    }
+
+    var referenceURLString: String {
+        switch self {
+        case .local(let attachment):
+            return "attachment://draft/\(attachment.id.uuidString.lowercased())"
+        case .remote(let descriptor):
+            return "attachment://\(descriptor.id.lowercased())"
+        }
+    }
+
+    var markdownReference: String {
+        let escapedName = fileName
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "]", with: "\\]")
+        return "[\(escapedName)](\(referenceURLString))"
+    }
+
+    static func validateCollection(_ attachments: [ComposerAttachmentItem]) throws {
+        guard attachments.count <= ChatDraftAttachment.maxAttachmentsPerMessage else {
+            throw WiredError(
+                withTitle: "Attachment",
+                message: "You can attach at most \(ChatDraftAttachment.maxAttachmentsPerMessage) files to a post."
+            )
+        }
+
+        let totalSize = attachments.reduce(UInt64(0)) { partialResult, attachment in
+            partialResult + attachment.size
+        }
+
+        guard totalSize <= ChatDraftAttachment.maxTotalSizeBytes else {
+            throw WiredError(
+                withTitle: "Attachment",
+                message: "These attachments are too large together. Attachments are currently limited to \(byteCountFormatter.string(fromByteCount: Int64(ChatDraftAttachment.maxTotalSizeBytes))) per message."
+            )
+        }
+    }
+}
+
 private extension String {
     var nilIfEmpty: String? {
         isEmpty ? nil : self

--- a/Wired 3/Models/ChatEvent.swift
+++ b/Wired 3/Models/ChatEvent.swift
@@ -42,6 +42,7 @@ final class ChatEvent: Identifiable {
     var text: String
     var type: ChatEventType
     var date = Date()
+    var attachments: [ChatAttachmentDescriptor]
 
     /// When non-nil, overrides `user.id == runtime.userID` for display alignment.
     /// Set for archived messages where the original userID may differ from the current session.
@@ -62,11 +63,29 @@ final class ChatEvent: Identifiable {
     }
 
     init(chat: Chat, user: User, type: ChatEventType, text: String, date: Date = Date()) {
+        self.attachments = []
         self.id = UUID()
         self.chat = chat
         self.user = user
         self.text = text
         self.type = type
         self.date = date
+    }
+
+    init(
+        chat: Chat,
+        user: User,
+        type: ChatEventType,
+        text: String,
+        date: Date = Date(),
+        attachments: [ChatAttachmentDescriptor]
+    ) {
+        self.id = UUID()
+        self.chat = chat
+        self.user = user
+        self.text = text
+        self.type = type
+        self.date = date
+        self.attachments = attachments
     }
 }

--- a/Wired 3/SwiftData/StoredPrivateMessage.swift
+++ b/Wired 3/SwiftData/StoredPrivateMessage.swift
@@ -15,6 +15,7 @@ final class StoredPrivateMessage {
     var text: String
     var date: Date
     var isFromCurrentUser: Bool
+    var attachmentDescriptorsData: Data?
     var conversation: StoredPrivateConversation?
 
     init(
@@ -25,6 +26,7 @@ final class StoredPrivateMessage {
         text: String,
         date: Date,
         isFromCurrentUser: Bool,
+        attachmentDescriptorsData: Data?,
         conversation: StoredPrivateConversation
     ) {
         self.eventID = eventID
@@ -34,6 +36,7 @@ final class StoredPrivateMessage {
         self.text = text
         self.date = date
         self.isFromCurrentUser = isFromCurrentUser
+        self.attachmentDescriptorsData = attachmentDescriptorsData
         self.conversation = conversation
     }
 }

--- a/Wired 3Tests/Wired_3Tests.swift
+++ b/Wired 3Tests/Wired_3Tests.swift
@@ -1056,6 +1056,18 @@ private final class TestFileService: @preconcurrency FileServiceProtocol {
         connection: AsyncConnection
     ) async throws { }
 
+    func setFileComment(
+        path: String,
+        comment: String,
+        connection: AsyncConnection
+    ) async throws { }
+
+    func setFileLabel(
+        path: String,
+        label: FileLabelValue,
+        connection: AsyncConnection
+    ) async throws { }
+
     func setFilePermissions(
         path: String,
         permissions: DropboxPermissions,

--- a/Wired-macOS.xcodeproj/project.pbxproj
+++ b/Wired-macOS.xcodeproj/project.pbxproj
@@ -32,6 +32,8 @@
 		4C0C2E2D2EFDB93B00213277 /* Topic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C0C2E2C2EFDB93A00213277 /* Topic.swift */; };
 		4C0C2E2F2EFDB95100213277 /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C0C2E2E2EFDB95000213277 /* User.swift */; };
 		4C0C2E312EFDB97300213277 /* ChatEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C0C2E302EFDB97200213277 /* ChatEvent.swift */; };
+		AB1000013000000100213277 /* ChatAttachment.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB1000023000000100213277 /* ChatAttachment.swift */; };
+		AB1000033000000100213277 /* ChatAttachmentViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB1000043000000100213277 /* ChatAttachmentViews.swift */; };
 		4C0C2E332EFDBA9E00213277 /* ChatMeMessageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C0C2E322EFDBA9E00213277 /* ChatMeMessageView.swift */; };
 		4C0C2E352EFDBD4000213277 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C0C2E342EFDBD4000213277 /* SettingsView.swift */; };
 		4C0C2E382EFF06BF00213277 /* DebouncedOnChange in Frameworks */ = {isa = PBXBuildFile; productRef = 4C0C2E372EFF06BF00213277 /* DebouncedOnChange */; };
@@ -176,6 +178,8 @@
 		4C0C2E2C2EFDB93A00213277 /* Topic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Topic.swift; sourceTree = "<group>"; };
 		4C0C2E2E2EFDB95000213277 /* User.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = User.swift; sourceTree = "<group>"; };
 		4C0C2E302EFDB97200213277 /* ChatEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatEvent.swift; sourceTree = "<group>"; };
+		AB1000023000000100213277 /* ChatAttachment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatAttachment.swift; sourceTree = "<group>"; };
+		AB1000043000000100213277 /* ChatAttachmentViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatAttachmentViews.swift; sourceTree = "<group>"; };
 		4C0C2E322EFDBA9E00213277 /* ChatMeMessageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMeMessageView.swift; sourceTree = "<group>"; };
 		4C0C2E342EFDBD4000213277 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		4C0C2E392F00421F00213277 /* ChatUsersList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatUsersList.swift; sourceTree = "<group>"; };
@@ -377,6 +381,7 @@
 				4C0C2E3F2F012F3E00213277 /* UserListRowView.swift */,
 				4C0C2E1B2EFD7C4E00213277 /* ChatTopicView.swift */,
 				4C0C2E3B2F0042FA00213277 /* ChatMessagesView.swift */,
+				AB1000043000000100213277 /* ChatAttachmentViews.swift */,
 				4C0C2E1D2EFD7C6300213277 /* ChatSayMessageView.swift */,
 				4C0C2E322EFDBA9E00213277 /* ChatMeMessageView.swift */,
 				4C0C2E1F2EFD7DD200213277 /* ChatEventView.swift */,
@@ -422,6 +427,7 @@
 			isa = PBXGroup;
 			children = (
 				4C0C2E302EFDB97200213277 /* ChatEvent.swift */,
+				AB1000023000000100213277 /* ChatAttachment.swift */,
 				4C0C2E2A2EFDB92100213277 /* Chat.swift */,
 				4C0C2E282EFDB90A00213277 /* ConnectionState.swift */,
 				4C0C2E2C2EFDB93A00213277 /* Topic.swift */,
@@ -845,6 +851,7 @@
 				4CBF0A042F879481004196FD /* ReplyView.swift in Sources */,
 				4CBF0A052F879481004196FD /* ThreadSortMenuView.swift in Sources */,
 				4C0C2E312EFDB97300213277 /* ChatEvent.swift in Sources */,
+				AB1000013000000100213277 /* ChatAttachment.swift in Sources */,
 				4C0C2E3C2F0042FA00213277 /* ChatMessagesView.swift in Sources */,
 				4C39DEBB2F1AB4BC009D54B1 /* FileFormView.swift in Sources */,
 				4CF01A922F20000100213277 /* FileInfoSheet.swift in Sources */,
@@ -908,6 +915,7 @@
 				4C8D11042F30000100213277 /* StoredBroadcastMessage.swift in Sources */,
 				4C8D11052F30000100213277 /* StoredMessageSelection.swift in Sources */,
 				4C0C2E072EF5C84000213277 /* ConnectionRuntime.swift in Sources */,
+				AB1000033000000100213277 /* ChatAttachmentViews.swift in Sources */,
 				4C0C2E1E2EFD7C6300213277 /* ChatSayMessageView.swift in Sources */,
 				4C8A826B2F5ED07200C271A8 /* MessageConversationDetailView.swift in Sources */,
 				4C0C2E482F07F6EF00213277 /* View.swift in Sources */,


### PR DESCRIPTION
## Summary
Comprehensive implementation of attachment functionality across the application, including rich file handling, chat attachments, board post attachments, and message previews.

## Changes

### Core Features
- **Chat Attachments**: Full attachment support for chat messages with preview and metadata handling
- **Board Attachments**: Attachment composition and preview for board posts and replies
- **Private Messages**: Attachment metadata persistence and Quick Look preview for images
- **File System**: Enhanced file preview column with labels, sync pair info, and Finder icon tinting

### New Models & Protocols
- `ChatAttachment` model for attachment metadata and management
- `ChatEvent` enhancements for attachment support
- `FileServiceProtocol` for file operations abstraction
- `FileItem` model for file handling

### UI Components
- `MarkdownComposer`: Expanded with attachment handling and preview
- `ChatAttachmentViews`: New comprehensive attachment views for chat
- Enhanced `ChatView`, `ChatMessagesView`, and message type views
- Improved file browser with label picker and column enhancements
- `FileInfoSheet` with extended metadata display

### Infrastructure
- `ConnectionRuntime` expanded with attachment-related operations
- `StoredPrivateMessage` persistence for attachment data
- AppKit file browser support improvements

## Files Modified
34 files changed, 3341 insertions(+), 346 deletions(-)