### PR TITLE
fix(ui): prevent duplicate window tab on connection open

### DIFF
--- a/Wired 3/Views/Main/MainView.swift
+++ b/Wired 3/Views/Main/MainView.swift
@@ -239,8 +239,16 @@ struct MainView: View {
             .sheet(item: newConnectionSheetBinding) { draft in
                 NewConnectionFormView(draft: draft) { id in
                     connectionController.suppressPresentedNewConnectionSheet = true
-                    connectionController.requestedSelectionID = id
-                    openMainTab()
+                    if windowConnectionID == nil {
+                        // Reuse the current (empty) window — avoids a duplicate tab
+                        // that would also pick up the same connection via restoreWindowConnectionIfNeeded.
+                        windowConnectionID = id
+                        listSelection = .connection(id)
+                        connectionController.activeConnectionID = id
+                    } else {
+                        connectionController.requestedSelectionID = id
+                        openMainTab()
+                    }
                     DispatchQueue.main.asyncAfter(deadline: .now() + 0.35) {
                         connectionController.suppressPresentedNewConnectionSheet = false
                     }
@@ -1090,8 +1098,14 @@ struct MainView: View {
         }
 
 #if os(macOS)
-        connectionController.requestedSelectionID = connectionID
-        openMainTab()
+        if windowConnectionID == nil {
+            windowConnectionID = connectionID
+            listSelection = .connection(connectionID)
+            connectionController.activeConnectionID = connectionID
+        } else {
+            connectionController.requestedSelectionID = connectionID
+            openMainTab()
+        }
 #else
         selectConnection(connectionID)
 #endif

--- a/Wired 3/Views/Main/MainView.swift
+++ b/Wired 3/Views/Main/MainView.swift
@@ -1325,11 +1325,10 @@ struct MainView: View {
     private func handleConnectionPrimaryAction(_ selection: Set<UUID>) {
         guard let id = selection.first else { return }
         if let bookmark = bookmark(for: id) {
-            if isConnectionActive(id) {
-                openOrSelectBookmark(bookmark)
-            } else {
-                connectInNewTab(bookmark)
-            }
+            // openOrSelectBookmark already handles all cases correctly:
+            // active → focus existing window; inactive + empty window → reuse it;
+            // inactive + occupied window → open a new tab.
+            openOrSelectBookmark(bookmark)
             return
         }
 


### PR DESCRIPTION
## Summary

- **Reuse empty window on first connect**: When a bookmark is double-clicked (or a new connection is created via the New Connection form or Tracker) and the current window has no active connection, the connection is now opened in-place instead of spawning a redundant second tab.
- **Fix `handleConnectionPrimaryAction` routing**: Previously, clicking a disconnected bookmark always called `connectInNewTab`, opening a new tab even when the existing window was empty. It now routes through `openOrSelectBookmark`, which already has the correct logic: focus the existing window if the connection is active; reuse the current window if it is empty; open a new tab only when the current window is already occupied.
- **Fix New Connection form and Tracker**: Both code paths now check `windowConnectionID == nil` before calling `openMainTab()`, so they also reuse an empty window rather than creating a duplicate tab.

## Test plan

- [ ] Cold start: double-click a bookmark → exactly one tab opens, connection established
- [ ] Occupied window: double-click a second bookmark → new tab opens for the second connection
- [ ] Active connection: double-click the same bookmark again → existing tab is focused, no new tab
- [ ] New Connection form from empty window → connection opens in the same window
- [ ] Tracker connect from empty window → connection opens in the same window

🤖 Generated with [Claude Code](https://claude.com/claude-code)