### PR TITLE
fix(navigation): Cmd+W returns to Public Chat instead of closing

### DIFF
--- a/Wired 3/Views/Main/MainView.swift
+++ b/Wired 3/Views/Main/MainView.swift
@@ -1675,6 +1675,15 @@ private final class WindowCloseDelegate: NSObject, NSWindowDelegate {
             return false
         }
 
+        // If the user is not on the Public Chat tab, Cmd+W navigates back to it
+        // instead of closing. The close/quit dialog only appears from the chat tab.
+        if let id = selectedConnectionID,
+           let runtime = connectionController?.runtime(for: id),
+           runtime.selectedTab != .chats {
+            runtime.selectedTab = .chats
+            return false
+        }
+
         guard checkBeforeClosing,
               let connectionController else {
             return true


### PR DESCRIPTION
## Summary

- When the user presses Cmd+W and the active connection is **not** on the Public Chat tab, the window now navigates back to Public Chat instead of showing the quit/close dialog.
- Behaviour is unchanged when the user is already on the Public Chat tab (existing close/quit logic applies).

## Motivation

Cmd+W is the standard macOS shortcut for "close the current context". In a chat client, the natural expectation is that it dismisses the current panel (files, boards, messages, etc.) and returns to the chat — not that it quits or closes the window. This makes the shortcut consistent with how other tabbed macOS apps behave.

## Change

**`Wired 3/Views/Main/MainView.swift`** — `WindowCloseDelegate.windowShouldClose`:
```swift
if let id = selectedConnectionID,
   let runtime = connectionController?.runtime(for: id),
   runtime.selectedTab != .chats {
    runtime.selectedTab = .chats
    return false
}
```

## Test plan

- [ ] Open a connection, switch to Files (or Boards, Messages, etc.), press Cmd+W → should navigate to Public Chat
- [ ] On the Public Chat tab, press Cmd+W → existing close/quit dialog should appear
- [ ] With no active connection, Cmd+W → existing behaviour unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)