### PR TITLE
feat(i18n): add German localization and complete French/English strings coverage

### DIFF
--- a/Wired 3/App/SettingsView.swift
+++ b/Wired 3/App/SettingsView.swift
@@ -26,10 +26,10 @@ struct SettingsView: View {
 
         var title: String {
             switch self {
-            case .general: return "General"
-            case .chat: return "Chat"
-            case .files: return "Files"
-            case .events: return "Events"
+            case .general: return NSLocalizedString("General", comment: "")
+            case .chat: return NSLocalizedString("Chat", comment: "")
+            case .files: return NSLocalizedString("Files", comment: "")
+            case .events: return NSLocalizedString("Events", comment: "")
             }
         }
 

--- a/Wired 3/App/Wired3App.swift
+++ b/Wired 3/App/Wired3App.swift
@@ -60,22 +60,22 @@ final class AppTerminationDelegate: NSObject, NSApplicationDelegate {
 
         let alert = NSAlert()
         if !activeConnectionIDs.isEmpty && hasActiveTransfers {
-            alert.messageText = "Active connections and transfers"
-            alert.informativeText = "There are \(activeConnectionIDs.count) active connections and active transfers. Quitting now will stop transfers."
-            alert.addButton(withTitle: "Disconnect and Quit")
-            alert.addButton(withTitle: "Cancel")
+            alert.messageText = NSLocalizedString("Active connections and transfers", comment: "")
+            alert.informativeText = String.localizedStringWithFormat(NSLocalizedString("There are %lld active connections and active transfers. Quitting now will stop transfers.", comment: ""), activeConnectionIDs.count)
+            alert.addButton(withTitle: NSLocalizedString("Disconnect and Quit", comment: ""))
+            alert.addButton(withTitle: NSLocalizedString("Cancel", comment: ""))
         } else if !activeConnectionIDs.isEmpty {
-            alert.messageText = activeConnectionIDs.count == 1 ? "Active connection" : "Active connections"
+            alert.messageText = activeConnectionIDs.count == 1 ? NSLocalizedString("Active connection", comment: "") : NSLocalizedString("Active connections", comment: "")
             alert.informativeText = activeConnectionIDs.count == 1
-                ? "Do you want to disconnect the active connection before quitting?"
-                : "Do you want to disconnect \(activeConnectionIDs.count) active connections before quitting?"
-            alert.addButton(withTitle: "Disconnect and Quit")
-            alert.addButton(withTitle: "Cancel")
+                ? NSLocalizedString("Do you want to disconnect the active connection before quitting?", comment: "")
+                : String.localizedStringWithFormat(NSLocalizedString("Do you want to disconnect %lld active connections before quitting?", comment: ""), activeConnectionIDs.count)
+            alert.addButton(withTitle: NSLocalizedString("Disconnect and Quit", comment: ""))
+            alert.addButton(withTitle: NSLocalizedString("Cancel", comment: ""))
         } else {
-            alert.messageText = "Active transfers are in progress."
-            alert.informativeText = "Quitting now will stop active transfers."
-            alert.addButton(withTitle: "Quit Anyway")
-            alert.addButton(withTitle: "Cancel")
+            alert.messageText = NSLocalizedString("Active transfers are in progress.", comment: "")
+            alert.informativeText = NSLocalizedString("Quitting now will stop active transfers.", comment: "")
+            alert.addButton(withTitle: NSLocalizedString("Quit Anyway", comment: ""))
+            alert.addButton(withTitle: NSLocalizedString("Cancel", comment: ""))
         }
         alert.alertStyle = .warning
         switch alert.runModal() {
@@ -405,7 +405,7 @@ private enum OverlayGlyphs {
             (Bundle.main.object(forInfoDictionaryKey: "CFBundleDisplayName") as? String) ??
             (Bundle.main.object(forInfoDictionaryKey: "CFBundleName") as? String) ??
             "App"
-        return "About \(appName)"
+        return NSLocalizedString("About \(appName)", comment: "")
     }
 
     static var leftLine: String { decode([163, 140, 143, 147, 133, 192, 148, 136, 133, 192, 151, 143, 146, 140, 132, 204], key: 0xE0) }

--- a/Wired 3/App/Wired3App.swift
+++ b/Wired 3/App/Wired3App.swift
@@ -61,7 +61,10 @@ final class AppTerminationDelegate: NSObject, NSApplicationDelegate {
         let alert = NSAlert()
         if !activeConnectionIDs.isEmpty && hasActiveTransfers {
             alert.messageText = NSLocalizedString("Active connections and transfers", comment: "")
-            alert.informativeText = String.localizedStringWithFormat(NSLocalizedString("There are %lld active connections and active transfers. Quitting now will stop transfers.", comment: ""), activeConnectionIDs.count)
+            let format = NSLocalizedString(
+                "There are %lld active connections and active transfers. Quitting now will stop transfers.",
+                comment: "")
+            alert.informativeText = String.localizedStringWithFormat(format, activeConnectionIDs.count)
             alert.addButton(withTitle: NSLocalizedString("Disconnect and Quit", comment: ""))
             alert.addButton(withTitle: NSLocalizedString("Cancel", comment: ""))
         } else if !activeConnectionIDs.isEmpty {

--- a/Wired 3/Features/Boards/Views/BoardPathActionView.swift
+++ b/Wired 3/Features/Boards/Views/BoardPathActionView.swift
@@ -41,7 +41,7 @@ public struct BoardPathActionView: View {
     public var body: some View {
         VStack(spacing: 0) {
             HStack {
-                Text(title)
+                Text(LocalizedStringKey(title))
                     .font(.headline)
                 Spacer()
             }
@@ -63,7 +63,7 @@ public struct BoardPathActionView: View {
                 Spacer()
                 Button("Cancel") { dismiss() }
                     .keyboardShortcut(.cancelAction)
-                Button(actionLabel) { apply() }
+                Button(LocalizedStringKey(actionLabel)) { apply() }
                     .keyboardShortcut(.defaultAction)
                     .disabled(!canSubmit)
             }

--- a/Wired 3/Features/Boards/Views/BoardsView.swift
+++ b/Wired 3/Features/Boards/Views/BoardsView.swift
@@ -413,7 +413,9 @@ struct BoardsView: View {
     }
 
     private func threadReadStateLabel(for thread: BoardThread) -> String {
-        thread.unreadPostsCount + thread.unreadReactionCount > 0 ? "Mark as Read" : "Mark as Unread"
+        thread.unreadPostsCount + thread.unreadReactionCount > 0
+            ? NSLocalizedString("Mark as Read", comment: "")
+            : NSLocalizedString("Mark as Unread", comment: "")
     }
 
     private func toggleThreadReadState(_ thread: BoardThread) {
@@ -664,7 +666,7 @@ struct BoardsView: View {
                 .navigationTitle("Boards")
         } else if selectedThreadUUID == nil {
             threadsList
-                .navigationTitle(selectedBoard?.name ?? selectedSmartBoard?.name ?? "Threads")
+                .navigationTitle(selectedBoard?.name ?? selectedSmartBoard?.name ?? NSLocalizedString("Threads", comment: ""))
                 .toolbar {
                     ToolbarItem(placement: .navigationBarLeading) {
                         Button("Boards") {
@@ -676,7 +678,7 @@ struct BoardsView: View {
                 }
         } else {
             postsDetail
-                .navigationTitle(selectedThread?.subject ?? "Posts")
+                .navigationTitle(selectedThread?.subject ?? NSLocalizedString("Posts", comment: ""))
                 .toolbar {
                     ToolbarItem(placement: .navigationBarLeading) {
                         Button("Threads") {

--- a/Wired 3/Features/Boards/Views/EditBoardPermissionsView.swift
+++ b/Wired 3/Features/Boards/Views/EditBoardPermissionsView.swift
@@ -100,7 +100,7 @@ struct EditBoardPermissionsView: View {
                     }
                     .disabled(isLoading || isSaving)
 
-                    Picker("Tout le monde", selection: $everyoneLevel) {
+                    Picker("Everyone", selection: $everyoneLevel) {
                         ForEach(PermissionLevel.allCases) { level in
                             Text(level.label).tag(level)
                         }

--- a/Wired 3/Features/Boards/Views/NewBoardView.swift
+++ b/Wired 3/Features/Boards/Views/NewBoardView.swift
@@ -116,7 +116,7 @@ struct NewBoardView: View {
                         }
                     }
 
-                    Picker("Tout le monde", selection: $everyoneLevel) {
+                    Picker("Everyone", selection: $everyoneLevel) {
                         ForEach(PermissionLevel.allCases) { level in
                             Text(level.label).tag(level)
                         }
@@ -126,7 +126,7 @@ struct NewBoardView: View {
             .formStyle(.grouped)
             .overlay {
                 if isLoadingAccounts {
-                    ProgressView("Chargement des comptes…")
+                    ProgressView("Loading accounts…")
                 }
             }
 

--- a/Wired 3/Features/Boards/Views/SmartBoardEditorView.swift
+++ b/Wired 3/Features/Boards/Views/SmartBoardEditorView.swift
@@ -68,7 +68,7 @@ struct SmartBoardEditorView: View {
     }
 
     private var title: String {
-        initialValue == nil ? "New Smart Board" : "Edit Smart Board"
+        initialValue == nil ? NSLocalizedString("New Smart Board", comment: "") : NSLocalizedString("Edit Smart Board", comment: "")
     }
 
     var body: some View {

--- a/Wired 3/Features/Files/AppKitFileColumnTableView.swift
+++ b/Wired 3/Features/Files/AppKitFileColumnTableView.swift
@@ -227,7 +227,7 @@ struct AppKitFileColumnTableView: NSViewRepresentable {
         }
 
         let column = NSTableColumn(identifier: NSUserInterfaceItemIdentifier("ColumnName"))
-        column.title = "Name"
+        column.title = NSLocalizedString("Name", comment: "")
         column.minWidth = 220
         column.width = 300
         column.resizingMask = .autoresizingMask
@@ -484,36 +484,36 @@ struct AppKitFileColumnTableView: NSViewRepresentable {
                 statusIcon?.isHidden = true
                 statusSpinner?.isHidden = false
                 statusSpinner?.startAnimation(nil)
-                cell.toolTip = "Sync status pending"
+                cell.toolTip = NSLocalizedString("Sync status pending", comment: "")
             case .paused:
                 statusSpinner?.stopAnimation(nil)
                 statusIcon?.isHidden = false
                 statusIcon?.contentTintColor = .secondaryLabelColor
                 statusIcon?.image = NSImage(systemSymbolName: "pause.circle", accessibilityDescription: "Pair paused")
-                cell.toolTip = "Sync paused"
+                cell.toolTip = NSLocalizedString("Sync paused", comment: "")
             case .connecting, .syncing, .reconnecting:
                 statusIcon?.isHidden = true
                 statusSpinner?.isHidden = false
                 statusSpinner?.startAnimation(nil)
-                cell.toolTip = parent.syncPairStatusForItem(item) == .reconnecting ? "Sync reconnecting" : "Sync in progress"
+                cell.toolTip = parent.syncPairStatusForItem(item) == .reconnecting ? NSLocalizedString("Sync reconnecting", comment: "") : NSLocalizedString("Sync in progress", comment: "")
             case .connected:
                 statusSpinner?.stopAnimation(nil)
                 statusIcon?.isHidden = false
                 statusIcon?.contentTintColor = .systemGreen
                 statusIcon?.image = NSImage(systemSymbolName: "link.circle.fill", accessibilityDescription: "Pair connected")
-                cell.toolTip = "Sync connected"
+                cell.toolTip = NSLocalizedString("Sync connected", comment: "")
             case .error(let message):
                 statusSpinner?.stopAnimation(nil)
                 statusIcon?.isHidden = false
                 statusIcon?.contentTintColor = .systemOrange
                 statusIcon?.image = NSImage(systemSymbolName: "exclamationmark.triangle.fill", accessibilityDescription: "Pair error")
-                cell.toolTip = message ?? "Sync error"
+                cell.toolTip = message ?? NSLocalizedString("Sync error", comment: "")
             case .inactive:
                 statusSpinner?.stopAnimation(nil)
                 statusIcon?.isHidden = false
                 statusIcon?.contentTintColor = .secondaryLabelColor
                 statusIcon?.image = NSImage(systemSymbolName: "link.circle", accessibilityDescription: "Pair inactive")
-                cell.toolTip = "Sync inactive"
+                cell.toolTip = NSLocalizedString("Sync inactive", comment: "")
             }
             return cell
         }
@@ -843,39 +843,39 @@ struct AppKitFileColumnTableView: NSViewRepresentable {
         func makeContextMenu() -> NSMenu {
             let menu = NSMenu()
             menu.autoenablesItems = false
-            var item = menu.addItem(withTitle: "Get Info", action: #selector(contextGetInfo), keyEquivalent: "")
+            var item = menu.addItem(withTitle: NSLocalizedString("Get Info", comment: ""), action: #selector(contextGetInfo), keyEquivalent: "")
             item.image = NSImage(systemSymbolName: "info.circle", accessibilityDescription: nil)
-            
-            item = menu.addItem(withTitle: "Quick Look", action: #selector(contextQuickLook), keyEquivalent: "")
+
+            item = menu.addItem(withTitle: NSLocalizedString("Quick Look", comment: ""), action: #selector(contextQuickLook), keyEquivalent: "")
             item.image = NSImage(systemSymbolName: "eye", accessibilityDescription: nil)
-            
+
             menu.addItem(NSMenuItem.separator())
-            item = menu.addItem(withTitle: "New Folder", action: #selector(contextNewFolder), keyEquivalent: "")
+            item = menu.addItem(withTitle: NSLocalizedString("New Folder", comment: ""), action: #selector(contextNewFolder), keyEquivalent: "")
             item.image = NSImage(systemSymbolName: "folder.badge.plus", accessibilityDescription: nil)
-            
-            item = menu.addItem(withTitle: "Download", action: #selector(contextDownload), keyEquivalent: "")
+
+            item = menu.addItem(withTitle: NSLocalizedString("Download", comment: ""), action: #selector(contextDownload), keyEquivalent: "")
             item.image = NSImage(systemSymbolName: "arrow.down.circle", accessibilityDescription: nil)
-            
-            item = menu.addItem(withTitle: "Upload…", action: #selector(contextUpload), keyEquivalent: "")
+
+            item = menu.addItem(withTitle: NSLocalizedString("Upload…", comment: ""), action: #selector(contextUpload), keyEquivalent: "")
             item.image = NSImage(systemSymbolName: "arrow.up.circle", accessibilityDescription: nil)
 
             menu.addItem(makeLabelSubmenuItem(target: self))
 
             menu.addItem(NSMenuItem.separator())
-            item = menu.addItem(withTitle: "Delete", action: #selector(contextDelete), keyEquivalent: "")
+            item = menu.addItem(withTitle: NSLocalizedString("Delete", comment: ""), action: #selector(contextDelete), keyEquivalent: "")
             item.image = NSImage(systemSymbolName: "trash", accessibilityDescription: nil)
-            
+
             menu.addItem(NSMenuItem.separator())
-            let statusItem = menu.addItem(withTitle: "Sync Status: Pair inactive", action: nil, keyEquivalent: "")
+            let statusItem = menu.addItem(withTitle: NSLocalizedString("Sync Status: Pair inactive", comment: ""), action: nil, keyEquivalent: "")
             statusItem.tag = SyncContextMenuItemTag.status
-            let toggleItem = menu.addItem(withTitle: "Activate Sync Pair", action: #selector(contextToggleSyncPair), keyEquivalent: "")
+            let toggleItem = menu.addItem(withTitle: NSLocalizedString("Activate Sync Pair", comment: ""), action: #selector(contextToggleSyncPair), keyEquivalent: "")
             toggleItem.tag = SyncContextMenuItemTag.toggle
             toggleItem.image = NSImage(systemSymbolName: "link", accessibilityDescription: nil)
-            
-            let syncNowItem = menu.addItem(withTitle: "Sync Now", action: #selector(contextSyncNow), keyEquivalent: "")
+
+            let syncNowItem = menu.addItem(withTitle: NSLocalizedString("Sync Now", comment: ""), action: #selector(contextSyncNow), keyEquivalent: "")
             syncNowItem.tag = SyncContextMenuItemTag.syncNow
             syncNowItem.image = NSImage(systemSymbolName: "arrow.trianglehead.2.clockwise", accessibilityDescription: nil)
-            
+
             for item in menu.items {
                 item.target = self
             }
@@ -905,15 +905,15 @@ struct AppKitFileColumnTableView: NSViewRepresentable {
             }
 
             let selected = selectedItems()
-            menu.item(withTitle: "Quick Look")?.isEnabled = selected.contains(where: { RemoteQuickLookSupport.isPreviewable($0) })
-            menu.item(withTitle: "Download")?.isEnabled = selected.contains(where: { parent.canDownloadForItem($0) })
-            menu.item(withTitle: "Delete")?.isEnabled = selected.contains(where: { parent.canDeleteForItem($0) })
-            menu.item(withTitle: "Upload…")?.isEnabled = parent.canUploadToDirectory(contextDirectoryTarget)
+            menu.item(withTitle: NSLocalizedString("Quick Look", comment: ""))?.isEnabled = selected.contains(where: { RemoteQuickLookSupport.isPreviewable($0) })
+            menu.item(withTitle: NSLocalizedString("Download", comment: ""))?.isEnabled = selected.contains(where: { parent.canDownloadForItem($0) })
+            menu.item(withTitle: NSLocalizedString("Delete", comment: ""))?.isEnabled = selected.contains(where: { parent.canDeleteForItem($0) })
+            menu.item(withTitle: NSLocalizedString("Upload…", comment: ""))?.isEnabled = parent.canUploadToDirectory(contextDirectoryTarget)
             let canGetSelectedInfo: Bool = {
                 guard selected.count == 1, let item = selected.first else { return false }
                 return parent.canGetInfoForItem(item)
             }()
-            menu.item(withTitle: "Get Info")?.isEnabled = canGetSelectedInfo
+            menu.item(withTitle: NSLocalizedString("Get Info", comment: ""))?.isEnabled = canGetSelectedInfo
             let selectedSyncItem: FileItem? = {
                 guard selected.count == 1, let item = selected.first, item.type == .sync else { return nil }
                 return item
@@ -923,46 +923,46 @@ struct AppKitFileColumnTableView: NSViewRepresentable {
             if let syncStatusItem = menu.item(withTag: SyncContextMenuItemTag.status) {
                 switch syncState {
                 case .paused:
-                    syncStatusItem.title = "Sync Status: Paused"
+                    syncStatusItem.title = NSLocalizedString("Sync Status: Paused", comment: "")
                 case .connecting:
-                    syncStatusItem.title = "Sync Status: Connecting…"
+                    syncStatusItem.title = NSLocalizedString("Sync Status: Connecting…", comment: "")
                 case .connected:
-                    syncStatusItem.title = "Sync Status: Connected"
+                    syncStatusItem.title = NSLocalizedString("Sync Status: Connected", comment: "")
                 case .syncing:
-                    syncStatusItem.title = "Sync Status: Syncing…"
+                    syncStatusItem.title = NSLocalizedString("Sync Status: Syncing…", comment: "")
                 case .reconnecting:
-                    syncStatusItem.title = "Sync Status: Reconnecting…"
+                    syncStatusItem.title = NSLocalizedString("Sync Status: Reconnecting…", comment: "")
                 case .error(let message):
                     syncStatusItem.title = "Sync Status: Error\(message.map { " - \($0)" } ?? "")"
                 case .inactive:
-                    syncStatusItem.title = "Sync Status: Pair inactive"
+                    syncStatusItem.title = NSLocalizedString("Sync Status: Pair inactive", comment: "")
                 case .checking:
-                    syncStatusItem.title = "Sync Status: Updating…"
+                    syncStatusItem.title = NSLocalizedString("Sync Status: Updating…", comment: "")
                 case .hidden:
-                    syncStatusItem.title = "Sync Status: Pair inactive"
+                    syncStatusItem.title = NSLocalizedString("Sync Status: Pair inactive", comment: "")
                 }
                 syncStatusItem.isHidden = selectedSyncItem == nil
                 syncStatusItem.isEnabled = false
             }
             if let toggleItem = menu.item(withTag: SyncContextMenuItemTag.toggle) {
                 if selectedSyncItem == nil {
-                    toggleItem.title = "Activate Sync Pair"
+                    toggleItem.title = NSLocalizedString("Activate Sync Pair", comment: "")
                     toggleItem.isEnabled = false
                 } else if syncState == .checking {
-                    toggleItem.title = pairExists ? "Deactivate Sync Pair" : "Activate Sync Pair"
+                    toggleItem.title = pairExists ? NSLocalizedString("Deactivate Sync Pair", comment: "") : NSLocalizedString("Activate Sync Pair", comment: "")
                     toggleItem.isEnabled = false
                 } else if pairExists {
-                    toggleItem.title = "Deactivate Sync Pair"
+                    toggleItem.title = NSLocalizedString("Deactivate Sync Pair", comment: "")
                     toggleItem.isEnabled = true
                 } else {
-                    toggleItem.title = "Activate Sync Pair"
+                    toggleItem.title = NSLocalizedString("Activate Sync Pair", comment: "")
                     toggleItem.isEnabled = true
                 }
                 toggleItem.isHidden = selectedSyncItem == nil
             }
             menu.item(withTag: SyncContextMenuItemTag.syncNow)?.isHidden = selectedSyncItem == nil
             menu.item(withTag: SyncContextMenuItemTag.syncNow)?.isEnabled = selectedSyncItem != nil && pairExists && syncState != .checking
-            menu.item(withTitle: "New Folder")?.isEnabled = parent.canCreateFolderInDirectory(contextDirectoryTarget)
+            menu.item(withTitle: NSLocalizedString("New Folder", comment: ""))?.isEnabled = parent.canCreateFolderInDirectory(contextDirectoryTarget)
             if let labelItem = menu.item(withTag: LabelContextMenuItemTag.submenu) {
                 labelItem.isEnabled = parent.canSetLabel && !selectedItems().isEmpty
             }

--- a/Wired 3/Features/Files/AppKitFilesTreeView.swift
+++ b/Wired 3/Features/Files/AppKitFilesTreeView.swift
@@ -227,7 +227,7 @@ struct AppKitFilesTreeView: NSViewRepresentable {
         outlineView.allowsColumnResizing = true
 
         let column = NSTableColumn(identifier: ColumnID.name)
-        column.title = "Name"
+        column.title = NSLocalizedString("Name", comment: "")
         column.minWidth = 220
         column.width = 420
         column.resizingMask = .autoresizingMask
@@ -236,7 +236,7 @@ struct AppKitFilesTreeView: NSViewRepresentable {
         outlineView.outlineTableColumn = column
 
         let kindColumn = NSTableColumn(identifier: ColumnID.kind)
-        kindColumn.title = "Kind"
+        kindColumn.title = NSLocalizedString("Kind", comment: "")
         kindColumn.minWidth = 110
         kindColumn.width = 110
         kindColumn.resizingMask = .userResizingMask
@@ -244,7 +244,7 @@ struct AppKitFilesTreeView: NSViewRepresentable {
         outlineView.addTableColumn(kindColumn)
 
         let modifiedColumn = NSTableColumn(identifier: ColumnID.modified)
-        modifiedColumn.title = "Modified"
+        modifiedColumn.title = NSLocalizedString("Modified", comment: "")
         modifiedColumn.minWidth = 140
         modifiedColumn.width = 140
         modifiedColumn.resizingMask = .userResizingMask
@@ -252,7 +252,7 @@ struct AppKitFilesTreeView: NSViewRepresentable {
         outlineView.addTableColumn(modifiedColumn)
 
         let sizeColumn = NSTableColumn(identifier: ColumnID.size)
-        sizeColumn.title = "Size"
+        sizeColumn.title = NSLocalizedString("Size", comment: "")
         sizeColumn.minWidth = 100
         sizeColumn.width = 100
         sizeColumn.resizingMask = .userResizingMask
@@ -895,36 +895,36 @@ struct AppKitFilesTreeView: NSViewRepresentable {
                 statusIcon?.isHidden = true
                 statusSpinner?.isHidden = false
                 statusSpinner?.startAnimation(nil)
-                cell.toolTip = "Sync status pending"
+                cell.toolTip = NSLocalizedString("Sync status pending", comment: "")
             case .paused:
                 statusSpinner?.stopAnimation(nil)
                 statusIcon?.isHidden = false
                 statusIcon?.contentTintColor = .secondaryLabelColor
                 statusIcon?.image = NSImage(systemSymbolName: "pause.circle", accessibilityDescription: "Pair paused")
-                cell.toolTip = "Sync paused"
+                cell.toolTip = NSLocalizedString("Sync paused", comment: "")
             case .connecting, .syncing, .reconnecting:
                 statusIcon?.isHidden = true
                 statusSpinner?.isHidden = false
                 statusSpinner?.startAnimation(nil)
-                cell.toolTip = syncStatus == .reconnecting ? "Sync reconnecting" : "Sync in progress"
+                cell.toolTip = syncStatus == .reconnecting ? NSLocalizedString("Sync reconnecting", comment: "") : NSLocalizedString("Sync in progress", comment: "")
             case .connected:
                 statusSpinner?.stopAnimation(nil)
                 statusIcon?.isHidden = false
                 statusIcon?.contentTintColor = .systemGreen
                 statusIcon?.image = NSImage(systemSymbolName: "link.circle.fill", accessibilityDescription: "Pair connected")
-                cell.toolTip = "Sync connected"
+                cell.toolTip = NSLocalizedString("Sync connected", comment: "")
             case .error(let message):
                 statusSpinner?.stopAnimation(nil)
                 statusIcon?.isHidden = false
                 statusIcon?.contentTintColor = .systemOrange
                 statusIcon?.image = NSImage(systemSymbolName: "exclamationmark.triangle.fill", accessibilityDescription: "Pair error")
-                cell.toolTip = message ?? "Sync error"
+                cell.toolTip = message ?? NSLocalizedString("Sync error", comment: "")
             case .inactive:
                 statusSpinner?.stopAnimation(nil)
                 statusIcon?.isHidden = false
                 statusIcon?.contentTintColor = .secondaryLabelColor
                 statusIcon?.image = NSImage(systemSymbolName: "link.circle", accessibilityDescription: "Pair inactive")
-                cell.toolTip = "Sync inactive"
+                cell.toolTip = NSLocalizedString("Sync inactive", comment: "")
             }
             return cell
         }
@@ -1251,39 +1251,39 @@ struct AppKitFilesTreeView: NSViewRepresentable {
         func makeContextMenu() -> NSMenu {
             let menu = NSMenu()
             menu.autoenablesItems = false
-            var item = menu.addItem(withTitle: "Get Info", action: #selector(contextGetInfo), keyEquivalent: "")
+            var item = menu.addItem(withTitle: NSLocalizedString("Get Info", comment: ""), action: #selector(contextGetInfo), keyEquivalent: "")
             item.image = NSImage(systemSymbolName: "info.circle", accessibilityDescription: nil)
-            
-            item = menu.addItem(withTitle: "Quick Look", action: #selector(contextQuickLook), keyEquivalent: "")
+
+            item = menu.addItem(withTitle: NSLocalizedString("Quick Look", comment: ""), action: #selector(contextQuickLook), keyEquivalent: "")
             item.image = NSImage(systemSymbolName: "eye", accessibilityDescription: nil)
-            
+
             menu.addItem(NSMenuItem.separator())
-            item = menu.addItem(withTitle: "New Folder", action: #selector(contextNewFolder), keyEquivalent: "")
+            item = menu.addItem(withTitle: NSLocalizedString("New Folder", comment: ""), action: #selector(contextNewFolder), keyEquivalent: "")
             item.image = NSImage(systemSymbolName: "folder.badge.plus", accessibilityDescription: nil)
-            
-            item = menu.addItem(withTitle: "Download", action: #selector(contextDownload), keyEquivalent: "")
+
+            item = menu.addItem(withTitle: NSLocalizedString("Download", comment: ""), action: #selector(contextDownload), keyEquivalent: "")
             item.image = NSImage(systemSymbolName: "arrow.down.circle", accessibilityDescription: nil)
-            
-            item = menu.addItem(withTitle: "Upload…", action: #selector(contextUpload), keyEquivalent: "")
+
+            item = menu.addItem(withTitle: NSLocalizedString("Upload…", comment: ""), action: #selector(contextUpload), keyEquivalent: "")
             item.image = NSImage(systemSymbolName: "arrow.up.circle", accessibilityDescription: nil)
 
             menu.addItem(makeLabelSubmenuItem(target: self))
 
             menu.addItem(NSMenuItem.separator())
-            item = menu.addItem(withTitle: "Delete", action: #selector(contextDelete), keyEquivalent: "")
+            item = menu.addItem(withTitle: NSLocalizedString("Delete", comment: ""), action: #selector(contextDelete), keyEquivalent: "")
             item.image = NSImage(systemSymbolName: "trash", accessibilityDescription: nil)
-            
+
             menu.addItem(NSMenuItem.separator())
-            let statusItem = menu.addItem(withTitle: "Sync Status: Pair inactive", action: nil, keyEquivalent: "")
+            let statusItem = menu.addItem(withTitle: NSLocalizedString("Sync Status: Pair inactive", comment: ""), action: nil, keyEquivalent: "")
             statusItem.tag = SyncContextMenuItemTag.status
-            let toggleItem = menu.addItem(withTitle: "Activate Sync Pair", action: #selector(contextToggleSyncPair), keyEquivalent: "")
+            let toggleItem = menu.addItem(withTitle: NSLocalizedString("Activate Sync Pair", comment: ""), action: #selector(contextToggleSyncPair), keyEquivalent: "")
             toggleItem.tag = SyncContextMenuItemTag.toggle
             toggleItem.image = NSImage(systemSymbolName: "link", accessibilityDescription: nil)
-            
-            let syncNowItem = menu.addItem(withTitle: "Sync Now", action: #selector(contextSyncNow), keyEquivalent: "")
+
+            let syncNowItem = menu.addItem(withTitle: NSLocalizedString("Sync Now", comment: ""), action: #selector(contextSyncNow), keyEquivalent: "")
             syncNowItem.tag = SyncContextMenuItemTag.syncNow
             syncNowItem.image = NSImage(systemSymbolName: "arrow.trianglehead.2.clockwise", accessibilityDescription: nil)
-            
+
             for item in menu.items {
                 item.target = self
             }
@@ -1327,19 +1327,19 @@ struct AppKitFilesTreeView: NSViewRepresentable {
             let selectedItems = selectedRows.compactMap { row -> FileItem? in
                 (outlineView.item(atRow: row) as? OutlineNode)?.item
             }
-            if let quickLookItem = menu.item(withTitle: "Quick Look") {
+            if let quickLookItem = menu.item(withTitle: NSLocalizedString("Quick Look", comment: "")) {
                 quickLookItem.isEnabled = selectedItems.contains(where: { RemoteQuickLookSupport.isPreviewable($0) })
             }
-            if let downloadItem = menu.item(withTitle: "Download") {
+            if let downloadItem = menu.item(withTitle: NSLocalizedString("Download", comment: "")) {
                 downloadItem.isEnabled = selectedItems.contains(where: { parent.canDownloadForItem($0) })
             }
-            if let deleteItem = menu.item(withTitle: "Delete") {
+            if let deleteItem = menu.item(withTitle: NSLocalizedString("Delete", comment: "")) {
                 deleteItem.isEnabled = selectedItems.contains(where: { parent.canDeleteForItem($0) })
             }
-            if let uploadItem = menu.item(withTitle: "Upload…") {
+            if let uploadItem = menu.item(withTitle: NSLocalizedString("Upload…", comment: "")) {
                 uploadItem.isEnabled = parent.canUploadToDirectory(contextDirectoryTarget)
             }
-            if let infoItem = menu.item(withTitle: "Get Info") {
+            if let infoItem = menu.item(withTitle: NSLocalizedString("Get Info", comment: "")) {
                 let canGetSelectedInfo: Bool = {
                     guard selectedItems.count == 1, let item = selectedItems.first else { return false }
                     return parent.canGetInfoForItem(item)
@@ -1357,23 +1357,23 @@ struct AppKitFilesTreeView: NSViewRepresentable {
             if let syncStatusItem = menu.item(withTag: SyncContextMenuItemTag.status) {
                 switch syncState {
                 case .paused:
-                    syncStatusItem.title = "Sync Status: Paused"
+                    syncStatusItem.title = NSLocalizedString("Sync Status: Paused", comment: "")
                 case .connecting:
-                    syncStatusItem.title = "Sync Status: Connecting…"
+                    syncStatusItem.title = NSLocalizedString("Sync Status: Connecting…", comment: "")
                 case .connected:
-                    syncStatusItem.title = "Sync Status: Connected"
+                    syncStatusItem.title = NSLocalizedString("Sync Status: Connected", comment: "")
                 case .syncing:
-                    syncStatusItem.title = "Sync Status: Syncing…"
+                    syncStatusItem.title = NSLocalizedString("Sync Status: Syncing…", comment: "")
                 case .reconnecting:
-                    syncStatusItem.title = "Sync Status: Reconnecting…"
+                    syncStatusItem.title = NSLocalizedString("Sync Status: Reconnecting…", comment: "")
                 case .error(let message):
                     syncStatusItem.title = "Sync Status: Error\(message.map { " - \($0)" } ?? "")"
                 case .inactive:
-                    syncStatusItem.title = "Sync Status: Pair inactive"
+                    syncStatusItem.title = NSLocalizedString("Sync Status: Pair inactive", comment: "")
                 case .checking:
-                    syncStatusItem.title = "Sync Status: Updating…"
+                    syncStatusItem.title = NSLocalizedString("Sync Status: Updating…", comment: "")
                 case .hidden:
-                    syncStatusItem.title = "Sync Status: Pair inactive"
+                    syncStatusItem.title = NSLocalizedString("Sync Status: Pair inactive", comment: "")
                 }
                 syncStatusItem.isHidden = selectedSyncItem == nil
                 syncStatusItem.isEnabled = false
@@ -1381,16 +1381,16 @@ struct AppKitFilesTreeView: NSViewRepresentable {
 
             if let toggleItem = menu.item(withTag: SyncContextMenuItemTag.toggle) {
                 if selectedSyncItem == nil {
-                    toggleItem.title = "Activate Sync Pair"
+                    toggleItem.title = NSLocalizedString("Activate Sync Pair", comment: "")
                     toggleItem.isEnabled = false
                 } else if syncState == .checking {
-                    toggleItem.title = pairExists ? "Deactivate Sync Pair" : "Activate Sync Pair"
+                    toggleItem.title = pairExists ? NSLocalizedString("Deactivate Sync Pair", comment: "") : NSLocalizedString("Activate Sync Pair", comment: "")
                     toggleItem.isEnabled = false
                 } else if pairExists {
-                    toggleItem.title = "Deactivate Sync Pair"
+                    toggleItem.title = NSLocalizedString("Deactivate Sync Pair", comment: "")
                     toggleItem.isEnabled = true
                 } else {
-                    toggleItem.title = "Activate Sync Pair"
+                    toggleItem.title = NSLocalizedString("Activate Sync Pair", comment: "")
                     toggleItem.isEnabled = true
                 }
                 toggleItem.isHidden = selectedSyncItem == nil
@@ -1400,7 +1400,7 @@ struct AppKitFilesTreeView: NSViewRepresentable {
                 syncItem.isHidden = selectedSyncItem == nil
                 syncItem.isEnabled = canSyncNow
             }
-            if let newFolderItem = menu.item(withTitle: "New Folder") {
+            if let newFolderItem = menu.item(withTitle: NSLocalizedString("New Folder", comment: "")) {
                 newFolderItem.isEnabled = parent.canCreateFolderInDirectory(contextDirectoryTarget)
             }
             if let labelItem = menu.item(withTag: LabelContextMenuItemTag.submenu) {

--- a/Wired 3/Features/Files/FileInfoSheet.swift
+++ b/Wired 3/Features/Files/FileInfoSheet.swift
@@ -20,10 +20,10 @@ private enum DropboxAccessLevel: String, CaseIterable, Identifiable {
 
     var title: String {
         switch self {
-        case .denied:    return "No Access"
-        case .readWrite: return "Read & Write"
-        case .readOnly:  return "Read Only"
-        case .writeOnly: return "Write Only"
+        case .denied:    return NSLocalizedString("No Access", comment: "")
+        case .readWrite: return NSLocalizedString("Read & Write", comment: "")
+        case .readOnly:  return NSLocalizedString("Read Only", comment: "")
+        case .writeOnly: return NSLocalizedString("Write Only", comment: "")
         }
     }
 
@@ -50,10 +50,10 @@ private enum SyncAccessMode: String, CaseIterable, Identifiable {
 
     var title: String {
         switch self {
-        case .disabled:       return "Disabled"
-        case .serverToClient: return "Server → Client"
-        case .clientToServer: return "Client → Server"
-        case .bidirectional:  return "Bidirectional"
+        case .disabled:       return NSLocalizedString("Disabled", comment: "")
+        case .serverToClient: return NSLocalizedString("Server → Client", comment: "")
+        case .clientToServer: return NSLocalizedString("Client → Server", comment: "")
+        case .bidirectional:  return NSLocalizedString("Bidirectional", comment: "")
         }
     }
 
@@ -390,7 +390,7 @@ struct FileInfoSheet: View {
 
     private var folderCard: some View {
         infoCard(title: "Folder", systemImage: "folder") {
-            infoRow("Contains", "\(info.directoryCount) items")
+            infoRow("Contains", String(format: NSLocalizedString("%lld items", comment: ""), Int64(info.directoryCount)))
             cardDivider
             HStack {
                 Text("Type")
@@ -466,7 +466,7 @@ struct FileInfoSheet: View {
         accessBinding: Binding<DropboxAccessLevel>
     ) -> some View {
         HStack(spacing: 8) {
-            Text(label)
+            Text(LocalizedStringKey(label))
                 .font(.subheadline)
                 .frame(width: labelWidth, alignment: .leading)
 
@@ -541,7 +541,7 @@ struct FileInfoSheet: View {
     /// Row for a byte-size quota field. Shows a TextField (numeric) + unit label.
     private func quotaByteRow(_ label: String, bytes: Binding<UInt64>) -> some View {
         HStack {
-            Text(label)
+            Text(LocalizedStringKey(label))
                 .font(.subheadline)
                 .frame(width: 100, alignment: .leading)
             Spacer()
@@ -555,7 +555,7 @@ struct FileInfoSheet: View {
                 Text("bytes")
                     .font(.subheadline).foregroundStyle(.secondary)
             } else {
-                Text(bytes.wrappedValue == 0 ? "Unlimited" : ByteCountFormatter.string(fromByteCount: Int64(bytes.wrappedValue), countStyle: .file))
+                Text(bytes.wrappedValue == 0 ? NSLocalizedString("Unlimited", comment: "") : ByteCountFormatter.string(fromByteCount: Int64(bytes.wrappedValue), countStyle: .file))
                     .font(.subheadline)
             }
         }
@@ -564,7 +564,7 @@ struct FileInfoSheet: View {
 
     private func syncModeRow(_ label: String, _ binding: Binding<SyncAccessMode>) -> some View {
         HStack {
-            Text(label)
+            Text(LocalizedStringKey(label))
                 .font(.subheadline)
                 .frame(width: labelWidth, alignment: .leading)
             Spacer()
@@ -590,7 +590,7 @@ struct FileInfoSheet: View {
 
     private func infoRow(_ label: String, _ value: String) -> some View {
         HStack {
-            Text(label)
+            Text(LocalizedStringKey(label))
                 .font(.subheadline).foregroundStyle(.secondary)
             Spacer()
             Text(value)
@@ -605,7 +605,7 @@ struct FileInfoSheet: View {
         @ViewBuilder content: () -> Content
     ) -> some View {
         VStack(alignment: .leading, spacing: 0) {
-            Label(title, systemImage: systemImage)
+            Label(LocalizedStringKey(title), systemImage: systemImage)
                 .font(.caption).fontWeight(.semibold)
                 .foregroundStyle(.secondary)
                 .padding(.horizontal, 14).padding(.vertical, 8)

--- a/Wired 3/Features/Files/FileItem.swift
+++ b/Wired 3/Features/Files/FileItem.swift
@@ -20,15 +20,15 @@ enum FileType: UInt32, CustomStringConvertible {
     var description: String {
         switch self {
         case .file:
-            "File"
+            NSLocalizedString("File", comment: "")
         case .directory:
-            "Directory"
+            NSLocalizedString("Directory", comment: "")
         case .uploads:
-            "Uploads"
+            NSLocalizedString("Uploads Folder", comment: "")
         case .dropbox:
-            "Drop Box"
+            NSLocalizedString("Drop Box", comment: "")
         case .sync:
-            "Sync"
+            NSLocalizedString("Sync Folder", comment: "")
         }
     }
 

--- a/Wired 3/Features/Files/FilePreviewColumn.swift
+++ b/Wired 3/Features/Files/FilePreviewColumn.swift
@@ -81,7 +81,7 @@ struct FilePreviewColumn: View {
             }
             if item.type == .file && item.executable {
                 cardDivider
-                metaRow("Executable", "Yes")
+                metaRow("Executable", NSLocalizedString("Yes", comment: ""))
             }
             if item.type.isDirectoryLike {
                 cardDivider
@@ -196,7 +196,7 @@ struct FilePreviewColumn: View {
                 HStack(spacing: 5) {
                     Image(systemName: icon)
                         .font(.caption2).fontWeight(.semibold)
-                    Text(title)
+                    Text(LocalizedStringKey(title))
                         .font(.caption).fontWeight(.semibold)
                 }
                 .foregroundStyle(.secondary)
@@ -214,7 +214,7 @@ struct FilePreviewColumn: View {
 
     private func metaRow(_ label: String, _ value: String) -> some View {
         HStack(alignment: .firstTextBaseline) {
-            Text(label)
+            Text(LocalizedStringKey(label))
                 .font(.caption).foregroundStyle(.secondary)
             Spacer()
             Text(value)
@@ -235,7 +235,10 @@ struct FilePreviewColumn: View {
 
     private func containsString(for item: FileItem) -> String {
         guard item.hasDirectoryCount else { return "-" }
-        return item.directoryCount == 1 ? "1 item" : "\(item.directoryCount) items"
+        if item.directoryCount == 1 {
+            return NSLocalizedString("1 item", comment: "")
+        }
+        return String(format: NSLocalizedString("%lld items", comment: ""), Int64(item.directoryCount))
     }
 }
 
@@ -250,21 +253,21 @@ private struct SyncStatusInfo {
     static func from(_ status: SyncPairStatusDisplay) -> SyncStatusInfo {
         switch status {
         case .hidden, .inactive:
-            return .init(label: "Inactive",     icon: "link.circle",                        color: .secondary, spinning: false)
+            return .init(label: NSLocalizedString("Inactive", comment: ""),     icon: "link.circle",                        color: .secondary, spinning: false)
         case .checking:
-            return .init(label: "Checking…",    icon: "",                                   color: .secondary, spinning: true)
+            return .init(label: NSLocalizedString("Checking…", comment: ""),    icon: "",                                   color: .secondary, spinning: true)
         case .paused:
-            return .init(label: "Paused",       icon: "pause.circle.fill",                  color: .orange,    spinning: false)
+            return .init(label: NSLocalizedString("Paused", comment: ""),       icon: "pause.circle.fill",                  color: .orange,    spinning: false)
         case .connecting:
-            return .init(label: "Connecting…",  icon: "",                                   color: .blue,      spinning: true)
+            return .init(label: NSLocalizedString("Connecting…", comment: ""),  icon: "",                                   color: .blue,      spinning: true)
         case .connected:
-            return .init(label: "Connected",    icon: "checkmark.circle.fill",              color: .green,     spinning: false)
+            return .init(label: NSLocalizedString("Connected", comment: ""),    icon: "checkmark.circle.fill",              color: .green,     spinning: false)
         case .syncing:
-            return .init(label: "Syncing…",     icon: "",                                   color: .blue,      spinning: true)
+            return .init(label: NSLocalizedString("Syncing…", comment: ""),     icon: "",                                   color: .blue,      spinning: true)
         case .reconnecting:
-            return .init(label: "Reconnecting", icon: "",                                   color: .orange,    spinning: true)
+            return .init(label: NSLocalizedString("Reconnecting", comment: ""), icon: "",                                   color: .orange,    spinning: true)
         case .error:
-            return .init(label: "Error",        icon: "exclamationmark.triangle.fill",      color: .red,       spinning: false)
+            return .init(label: NSLocalizedString("Error", comment: ""),        icon: "exclamationmark.triangle.fill",      color: .red,       spinning: false)
         }
     }
 }
@@ -276,13 +279,13 @@ private struct SyncModeLabel {
     static func from(_ mode: SyncModeValue) -> SyncModeLabel {
         switch mode {
         case .disabled:
-            return .init(title: "Disabled",         icon: "slash.circle")
+            return .init(title: NSLocalizedString("Disabled", comment: ""),        icon: "slash.circle")
         case .serverToClient:
-            return .init(title: "Server → Client",  icon: "arrow.down.circle")
+            return .init(title: NSLocalizedString("Server → Client", comment: ""), icon: "arrow.down.circle")
         case .clientToServer:
-            return .init(title: "Client → Server",  icon: "arrow.up.circle")
+            return .init(title: NSLocalizedString("Client → Server", comment: ""), icon: "arrow.up.circle")
         case .bidirectional:
-            return .init(title: "Bidirectional",    icon: "arrow.2.circlepath")
+            return .init(title: NSLocalizedString("Bidirectional", comment: ""),   icon: "arrow.2.circlepath")
         }
     }
 }

--- a/Wired 3/Features/Files/FilesQuickLookController.swift
+++ b/Wired 3/Features/Files/FilesQuickLookController.swift
@@ -191,20 +191,14 @@ final class FilesQuickLookController: NSObject, QLPreviewPanelDataSource, QLPrev
         let alert = NSAlert()
         alert.alertStyle = .informational
         if items.count == 1, let item = items.first {
-            alert.messageText = "Download Preview?"
-            alert.informativeText = """
-            \(item.name) is not cached yet and is larger than 512 KB.
-            Wired will fetch a lightweight Quick Look preview from the server.
-            """
+            alert.messageText = NSLocalizedString("Download Preview?", comment: "")
+            alert.informativeText = String(format: NSLocalizedString("%@ is not cached yet and is larger than 512 KB.\nWired will fetch a lightweight Quick Look preview from the server.", comment: ""), item.name)
         } else {
-            alert.messageText = "Download Previews?"
-            alert.informativeText = """
-            \(items.count) selected files are not cached yet and are larger than 512 KB.
-            Wired will fetch lightweight Quick Look previews from the server.
-            """
+            alert.messageText = NSLocalizedString("Download Previews?", comment: "")
+            alert.informativeText = String(format: NSLocalizedString("%lld selected files are not cached yet and are larger than 512 KB.\nWired will fetch lightweight Quick Look previews from the server.", comment: ""), Int64(items.count))
         }
-        alert.addButton(withTitle: "Preview")
-        alert.addButton(withTitle: "Cancel")
+        alert.addButton(withTitle: NSLocalizedString("Preview", comment: ""))
+        alert.addButton(withTitle: NSLocalizedString("Cancel", comment: ""))
 
         return alert.runModal() == .alertFirstButtonReturn
     }
@@ -214,7 +208,7 @@ final class FilesQuickLookController: NSObject, QLPreviewPanelDataSource, QLPrev
         let nsError = error as NSError
         let alert = NSAlert()
         alert.alertStyle = .warning
-        alert.messageText = "Quick Look Error"
+        alert.messageText = NSLocalizedString("Quick Look Error", comment: "")
         alert.informativeText = nsError.localizedDescription
         if let window = windowProvider() {
             alert.beginSheetModal(for: window)

--- a/Wired 3/Features/Files/FilesView+Operations.swift
+++ b/Wired 3/Features/Files/FilesView+Operations.swift
@@ -30,7 +30,7 @@ extension FilesView {
             } label: {
                 Image(systemName: "chevron.left")
             }
-            .help("Navigate Backwark")
+            .help("Navigate Backward")
             .disabled(!canGoBack)
 
             Button {
@@ -170,11 +170,11 @@ extension FilesView {
     func askOverwrite(path: String) -> Bool {
 #if os(macOS)
         let alert = NSAlert()
-        alert.messageText = "File Already Exists"
-        alert.informativeText = "A file already exists at:\n\(path)\n\nOverwrite it?"
+        alert.messageText = NSLocalizedString("File Already Exists", comment: "")
+        alert.informativeText = String(format: NSLocalizedString("A file already exists at:\n%@\n\nOverwrite it?", comment: ""), path)
         alert.alertStyle = .warning
-        alert.addButton(withTitle: "Overwrite")
-        alert.addButton(withTitle: "Stop")
+        alert.addButton(withTitle: NSLocalizedString("Overwrite", comment: ""))
+        alert.addButton(withTitle: NSLocalizedString("Stop", comment: ""))
         return alert.runModal() == .alertFirstButtonReturn
 #else
         return false

--- a/Wired 3/Features/Files/FinderDragPromiseSupport.swift
+++ b/Wired 3/Features/Files/FinderDragPromiseSupport.swift
@@ -50,11 +50,11 @@ final class DragPlaceholderPromiseDelegate: NSObject, NSFilePromiseProviderDeleg
     @MainActor
     private func askOverwrite(path: String) -> Bool {
         let alert = NSAlert()
-        alert.messageText = "File Already Exists"
-        alert.informativeText = "Do you want to overwrite \"\(path)\"?"
+        alert.messageText = NSLocalizedString("File Already Exists", comment: "")
+        alert.informativeText = String(format: NSLocalizedString("Do you want to overwrite \"%@\"?", comment: ""), path)
         alert.alertStyle = .warning
-        alert.addButton(withTitle: "Overwrite")
-        alert.addButton(withTitle: "Stop")
+        alert.addButton(withTitle: NSLocalizedString("Overwrite", comment: ""))
+        alert.addButton(withTitle: NSLocalizedString("Stop", comment: ""))
         return alert.runModal() == .alertFirstButtonReturn
     }
 

--- a/Wired 3/Features/ServerInfo/Views/ServerInfoView.swift
+++ b/Wired 3/Features/ServerInfo/Views/ServerInfoView.swift
@@ -105,7 +105,7 @@ struct ServerInfoView: View {
             }
             .padding(.top, 4)
         } label: {
-            Text(title)
+            Text(LocalizedStringKey(title))
                 .font(.subheadline)
                 .fontWeight(.semibold)
                 .foregroundStyle(.secondary)
@@ -116,7 +116,7 @@ struct ServerInfoView: View {
     @ViewBuilder
     private func infoRow(_ label: String, value: String) -> some View {
         GridRow {
-            Text(label)
+            Text(LocalizedStringKey(label))
                 .foregroundStyle(.secondary)
                 .font(.subheadline)
                 .gridColumnAlignment(.leading)
@@ -133,7 +133,7 @@ struct ServerInfoView: View {
     @ViewBuilder
     private func infoTimerRow(_ label: String, since date: Date) -> some View {
         GridRow {
-            Text(label)
+            Text(LocalizedStringKey(label))
                 .foregroundStyle(.secondary)
                 .font(.subheadline)
                 .gridColumnAlignment(.leading)

--- a/Wired 3/Features/ServerSettings/Views/AccountsSettingsView.swift
+++ b/Wired 3/Features/ServerSettings/Views/AccountsSettingsView.swift
@@ -21,9 +21,9 @@ enum AccountFilter: String, CaseIterable, Identifiable {
 
     var title: String {
         switch self {
-        case .all: return "All"
-        case .users: return "Users"
-        case .groups: return "Groups"
+        case .all: return NSLocalizedString("All", comment: "")
+        case .users: return NSLocalizedString("Users", comment: "")
+        case .groups: return NSLocalizedString("Groups", comment: "")
         }
     }
 }
@@ -36,8 +36,8 @@ enum AccountDetailTab: String, CaseIterable, Identifiable {
 
     var title: String {
         switch self {
-        case .account: return "Account"
-        case .permissions: return "Permissions"
+        case .account: return NSLocalizedString("Account", comment: "")
+        case .permissions: return NSLocalizedString("Permissions", comment: "")
         }
     }
 }
@@ -50,8 +50,8 @@ enum AccountType: String, CaseIterable, Identifiable {
 
     var title: String {
         switch self {
-        case .user: return "User"
-        case .group: return "Group"
+        case .user: return NSLocalizedString("User", comment: "")
+        case .group: return NSLocalizedString("Group", comment: "")
         }
     }
 }
@@ -1242,7 +1242,7 @@ private struct AccountEditorForm: View {
 
     private func row<Content: View>(label: String, @ViewBuilder content: () -> Content) -> some View {
         HStack(alignment: .top) {
-            Text(label)
+            Text(LocalizedStringKey(label))
                 .frame(width: 140, alignment: .trailing)
                 .foregroundStyle(.secondary)
             content()
@@ -1277,7 +1277,7 @@ private struct AccountEditorForm: View {
 
     private func line(_ label: String, value: String) -> some View {
         HStack {
-            Text("\(label):")
+            Text("\(NSLocalizedString(label, comment: "")):")
                 .foregroundStyle(.secondary)
             Text(value)
         }
@@ -1423,17 +1423,17 @@ private enum PermissionCategory: String, CaseIterable, Hashable {
 
     var title: String {
         switch self {
-        case .basic: return "Basic"
-        case .files: return "Files"
-        case .messages: return "Messages"
-        case .transfers: return "Transfers"
-        case .boards: return "Boards"
-        case .users: return "Users"
-        case .accounts: return "Accounts"
-        case .administration: return "Administration"
-        case .tracker: return "Tracker"
-        case .limits: return "Limits"
-        case .other: return "Other"
+        case .basic: return NSLocalizedString("Basic", comment: "")
+        case .files: return NSLocalizedString("Files", comment: "")
+        case .messages: return NSLocalizedString("Messages", comment: "")
+        case .transfers: return NSLocalizedString("Transfers", comment: "")
+        case .boards: return NSLocalizedString("Boards", comment: "")
+        case .users: return NSLocalizedString("Users", comment: "")
+        case .accounts: return NSLocalizedString("Accounts", comment: "")
+        case .administration: return NSLocalizedString("Administration", comment: "")
+        case .tracker: return NSLocalizedString("Tracker", comment: "")
+        case .limits: return NSLocalizedString("Limits", comment: "")
+        case .other: return NSLocalizedString("Other", comment: "")
         }
     }
 
@@ -1500,17 +1500,17 @@ private enum PermissionCategory: String, CaseIterable, Hashable {
 }
 
 private func permissionDisplayName(_ key: String) -> String {
-    if key == "wired.account.color" {
-        return "Color"
+    let localized = NSLocalizedString(key, comment: "")
+    if localized != key {
+        return localized
     }
-
+    // Fallback: derive a readable name from the protocol key
     let short = key.replacingOccurrences(of: "wired.account.", with: "")
     let words = short
         .split(separator: ".")
         .joined(separator: " ")
         .split(separator: "_")
         .map { $0.capitalized }
-
     return words.joined(separator: " ")
 }
 
@@ -1526,12 +1526,12 @@ private enum WiredAccountColor: UInt32, CaseIterable, Identifiable {
 
     var title: String {
         switch self {
-        case .black: return "Black"
-        case .red: return "Red"
-        case .orange: return "Orange"
-        case .green: return "Green"
-        case .blue: return "Blue"
-        case .purple: return "Purple"
+        case .black: return NSLocalizedString("Black", comment: "")
+        case .red: return NSLocalizedString("Red", comment: "")
+        case .orange: return NSLocalizedString("Orange", comment: "")
+        case .green: return NSLocalizedString("Green", comment: "")
+        case .blue: return NSLocalizedString("Blue", comment: "")
+        case .purple: return NSLocalizedString("Purple", comment: "")
         }
     }
 

--- a/Wired 3/Features/ServerSettings/Views/ServerSettingsView.swift
+++ b/Wired 3/Features/ServerSettings/Views/ServerSettingsView.swift
@@ -14,12 +14,12 @@ private enum ServerSettingsCategory: String, CaseIterable, Identifiable {
 
     var title: String {
         switch self {
-        case .general: return "Settings"
-        case .monitor: return "Monitor"
-        case .events: return "Events"
-        case .log: return "Log"
-        case .accounts: return "Accounts"
-        case .bans: return "Bans"
+        case .general: return NSLocalizedString("Settings", comment: "")
+        case .monitor: return NSLocalizedString("Monitor", comment: "")
+        case .events: return NSLocalizedString("Events", comment: "")
+        case .log: return NSLocalizedString("Log", comment: "")
+        case .accounts: return NSLocalizedString("Accounts", comment: "")
+        case .bans: return NSLocalizedString("Bans", comment: "")
         }
     }
 
@@ -1076,7 +1076,7 @@ private struct GeneralServerSettingsView: View {
 
     private func trackerField<Content: View>(_ title: String, @ViewBuilder content: () -> Content) -> some View {
         VStack(alignment: .leading, spacing: 4) {
-            Text(title)
+            Text(LocalizedStringKey(title))
                 .font(.caption)
                 .foregroundStyle(.secondary)
             content()
@@ -1085,7 +1085,7 @@ private struct GeneralServerSettingsView: View {
 
     private func settingsNumericRow(_ label: String, value: Binding<Int>) -> some View {
         HStack(spacing: 8) {
-            Text("\(label) :")
+            Text("\(NSLocalizedString(label, comment: "")) :")
                 .frame(width: 170, alignment: .trailing)
                 .foregroundStyle(.secondary)
             TextField("", value: value, format: .number)
@@ -1097,7 +1097,7 @@ private struct GeneralServerSettingsView: View {
 
     private func speedLimitRow(_ label: String, value: Binding<Int>) -> some View {
         HStack(spacing: 8) {
-            Text("\(label) :")
+            Text("\(NSLocalizedString(label, comment: "")) :")
                 .frame(width: 140, alignment: .trailing)
                 .foregroundStyle(.secondary)
             TextField("", value: value, format: .number)
@@ -1117,7 +1117,7 @@ private struct GeneralServerSettingsView: View {
     ) -> some View {
         HStack(alignment: alignment, spacing: 10) {
             if labelWidth > 0 {
-                Text(label.isEmpty ? " " : "\(label) :")
+                Text(label.isEmpty ? " " : "\(NSLocalizedString(label, comment: "")) :")
                     .frame(width: labelWidth, alignment: .trailing)
                     .foregroundStyle(.secondary)
             }

--- a/Wired 3/Views/Main/ChangePasswordView.swift
+++ b/Wired 3/Views/Main/ChangePasswordView.swift
@@ -86,7 +86,7 @@ struct ChangePasswordView: View {
     private func submit() async {
         guard let runtime = controller.runtime(for: connectionID),
               let connection = runtime.connection as? AsyncConnection else {
-            errorMessage = "No active connection."
+            errorMessage = NSLocalizedString("No active connection.", comment: "")
             return
         }
 
@@ -100,7 +100,7 @@ struct ChangePasswordView: View {
         do {
             let response = try await connection.sendAsync(message)
             if let response, response.name == "wired.error" {
-                errorMessage = response.string(forField: "wired.error.string") ?? "Server error."
+                errorMessage = response.string(forField: "wired.error.string") ?? NSLocalizedString("Server error.", comment: "")
                 isLoading = false
                 return
             }

--- a/Wired 3/Views/Main/MainView.swift
+++ b/Wired 3/Views/Main/MainView.swift
@@ -1804,11 +1804,11 @@ private final class WindowCloseDelegate: NSObject, NSWindowDelegate {
         }
 
         let alert = NSAlert()
-        alert.messageText = "Active connection"
-        alert.informativeText = "Do you want to disconnect the active connection before closing this window/tab?"
+        alert.messageText = NSLocalizedString("Active connection", comment: "")
+        alert.informativeText = NSLocalizedString("Do you want to disconnect the active connection before closing this window/tab?", comment: "")
         alert.alertStyle = .warning
-        alert.addButton(withTitle: "Disconnect and Close")
-        alert.addButton(withTitle: "Cancel")
+        alert.addButton(withTitle: NSLocalizedString("Disconnect and Close", comment: ""))
+        alert.addButton(withTitle: NSLocalizedString("Cancel", comment: ""))
 
         switch alert.runModal() {
         case .alertFirstButtonReturn:

--- a/Wired 3/de.lproj/Localizable.strings
+++ b/Wired 3/de.lproj/Localizable.strings
@@ -1,0 +1,681 @@
+/* Wired 3 – German Localizable.strings */
+
+/* ── Navigation / Server Settings categories ── */
+"Settings" = "Einstellungen";
+"Monitor" = "Monitor";
+"Events" = "Ereignisse";
+"Accounts" = "Konten";
+"Bans" = "Sperren";
+
+/* ── General ── */
+"Cancel" = "Abbrechen";
+"Save" = "Sichern";
+"Delete" = "Löschen";
+"OK" = "OK";
+"Reload" = "Neu laden";
+"Refresh" = "Aktualisieren";
+"Add" = "Hinzufügen";
+"Create" = "Erstellen";
+"Disconnect" = "Trennen";
+"Search" = "Suchen";
+"Filter" = "Filter";
+"Type" = "Typ";
+"Name" = "Name";
+"Password" = "Passwort";
+"Group" = "Gruppe";
+"User" = "Benutzer";
+"Account" = "Konto";
+"Permissions" = "Berechtigungen";
+"Comment" = "Kommentar";
+"All" = "Alle";
+"Level" = "Ebene";
+"Never" = "Nie";
+"Date" = "Datum";
+"Category" = "Kategorie";
+"No" = "Nein";
+"Edit" = "Bearbeiten";
+"Remove" = "Entfernen";
+"Start" = "Starten";
+"Pause" = "Pause";
+"Stop" = "Stoppen";
+"Size" = "Größe";
+"Description" = "Beschreibung";
+"URL" = "URL";
+"Status" = "Status";
+"Info" = "Info";
+
+/* ── Monitor view ── */
+"Access Denied" = "Zugriff verweigert";
+"Required permission: wired.account.user.get_users" = "Erforderliche Berechtigung: wired.account.user.get_users";
+"Users" = "Benutzer";
+"Download" = "Download";
+"Upload" = "Upload";
+"Search user" = "Benutzer suchen";
+"No Users" = "Keine Benutzer";
+"No user matches the current filter." = "Kein Benutzer entspricht dem aktuellen Filter.";
+"Disconnect User" = "Benutzer trennen";
+"Message" = "Nachricht";
+"Optional message" = "Optionale Nachricht";
+"Idle" = "Inaktiv";
+"Connected" = "Verbunden";
+
+/* ── Server Settings ── */
+"Required permission: wired.account.settings.get_settings" = "Erforderliche Berechtigung: wired.account.settings.get_settings";
+"Loading Settings" = "Einstellungen werden geladen";
+"Retrieving server permissions and settings…" = "Serverberechtigungen und Einstellungen werden abgerufen…";
+"Server Name" = "Servername";
+"Banner" = "Banner";
+"Max size 400x64" = "Maximale Größe 400x64";
+"Choose an image…" = "Bild auswählen…";
+"Concurrent Downloads" = "Gleichzeitige Downloads";
+"DL Speed" = "DL-Geschwindigkeit";
+"Concurrent Uploads" = "Gleichzeitige Uploads";
+"UL Speed" = "UL-Geschwindigkeit";
+
+/* ── Navigation ── */
+"Favorites" = "Favoriten";
+"Connections" = "Verbindungen";
+"Trackers" = "Tracker";
+"Add Tracker" = "Tracker hinzufügen";
+"New Connection" = "Neue Verbindung";
+"Select an item" = "Element auswählen";
+"Chats" = "Chats";
+"Messages" = "Nachrichten";
+"Boards" = "Boards";
+"Files" = "Dateien";
+"Bookmark" = "Lesezeichen";
+"Connect" = "Verbinden";
+"Tracker" = "Tracker";
+"Loading tracker…" = "Tracker wird geladen…";
+"No servers listed" = "Keine Server aufgeführt";
+"Get Info" = "Infos anzeigen";
+"Add to Favorites" = "Zu Favoriten hinzufügen";
+"Add to Trackers" = "Zu Trackern hinzufügen";
+"Connection" = "Verbindung";
+
+/* ── Connection state ── */
+"Connecting…" = "Verbinde…";
+"Disconnected" = "Getrennt";
+"Connection unavailable" = "Verbindung nicht verfügbar";
+"Are you sure you want to disconnect from this server?" = "Möchten Sie wirklich vom Server trennen?";
+"Disconnect and Close" = "Trennen und schließen";
+
+/* ── Tracker / Directory ── */
+"Each directory is registered as a `wired://host[:port]/Category` URL. The interface edits the parts and serializes them automatically." = "Jedes Verzeichnis wird als `wired://Host[:Port]/Kategorie`-URL registriert. Die Oberfläche bearbeitet die Teile und serialisiert sie automatisch.";
+"Add Directory" = "Verzeichnis hinzufügen";
+"When enabled, this server responds to `wired.tracker.*` messages and exposes the categories below." = "Wenn aktiviert, antwortet dieser Server auf `wired.tracker.*`-Nachrichten und zeigt die unten aufgeführten Kategorien an.";
+"Directory Categories" = "Verzeichniskategorien";
+"New Category" = "Neue Kategorie";
+"Register server with the following directories" = "Server bei folgenden Verzeichnissen registrieren";
+"Enable Directory" = "Verzeichnis aktivieren";
+"Directory %lld" = "Verzeichnis %lld";
+"Host" = "Host";
+"Login" = "Benutzername";
+"Port" = "Port";
+"Registered URL" = "Registrierte URL";
+
+/* ── Bans ── */
+"No Bans" = "Keine Sperren";
+"Required permission: wired.account.banlist.get_bans" = "Erforderliche Berechtigung: wired.account.banlist.get_bans";
+"Add Ban" = "Sperre hinzufügen";
+"IP" = "IP";
+"Exact IPs, wildcards, CIDR and network masks are supported." = "Genaue IPs, Platzhalter, CIDR und Netzwerkmasken werden unterstützt.";
+"Expires" = "Läuft ab";
+
+/* ── Events ── */
+"Recent Events" = "Neueste Ereignisse";
+"Required permission: wired.account.events.view_events" = "Erforderliche Berechtigung: wired.account.events.view_events";
+"No Events" = "Keine Ereignisse";
+"Period" = "Zeitraum";
+"Nick" = "Nick";
+"All Nicks" = "Alle Nicks";
+"All Logins" = "Alle Benutzernamen";
+"All IPs" = "Alle IPs";
+"All Categories" = "Alle Kategorien";
+"All Levels" = "Alle Ebenen";
+"Section under development" = "Abschnitt in Entwicklung";
+
+/* ── Log ── */
+"No Entries" = "Keine Einträge";
+"Required permission: wired.account.log.view_log" = "Erforderliche Berechtigung: wired.account.log.view_log";
+
+/* ── Accounts ── */
+"Groups" = "Gruppen";
+"Delete Account" = "Konto löschen";
+"Delete User" = "Benutzer löschen";
+"Delete Group" = "Gruppe löschen";
+"Required permission: wired.account.account.list_accounts" = "Erforderliche Berechtigung: wired.account.account.list_accounts";
+"No Accounts" = "Keine Konten";
+"Select an Account" = "Konto auswählen";
+"Remove Password" = "Passwort entfernen";
+"Account Name" = "Kontoname";
+"Full Name" = "Vollständiger Name";
+"Primary Group" = "Primäre Gruppe";
+"Optional" = "Optional";
+"Secondary Groups" = "Sekundäre Gruppen";
+"Comma-separated" = "Kommagetrennt";
+"Example: staff, moderators" = "Beispiel: staff, moderators";
+
+/* ── Chat / User list ── */
+"Online" = "Online";
+"Offline" = "Offline";
+"Get Infos" = "Infos anzeigen";
+"Send Private Message" = "Private Nachricht senden";
+"Invite to Private Chat" = "In privaten Chat einladen";
+"Kick" = "Rauswerfen";
+"Ban" = "Sperren";
+"Kick User" = "Benutzer rauswerfen";
+"Ban User" = "Benutzer sperren";
+"Chat here…" = "Hier chatten…";
+"Add a message or press Return to send…" = "Nachricht eingeben oder Return drücken zum Senden…";
+
+/* ── User info panel ── */
+"App version" = "App-Version";
+"P7 Protocol" = "P7-Protokoll";
+"Wired Protocol" = "Wired-Protokoll";
+"OS Name" = "Betriebssystem";
+"OS Version" = "BS-Version";
+"Arch" = "Architektur";
+"IP Address" = "IP-Adresse";
+"Hostname" = "Hostname";
+"Cipher" = "Verschlüsselung";
+"Login Time" = "Anmeldezeit";
+"Idle Time" = "Inaktiv seit";
+"Transfer" = "Übertragung";
+
+/* ── Messages ── */
+"Private Messages" = "Private Nachrichten";
+"Broadcasts" = "Rundsendungen";
+"No Results" = "Keine Ergebnisse";
+"Select a Conversation" = "Konversation auswählen";
+"No Conversation" = "Keine Konversation";
+"Open a conversation from the users list." = "Öffne eine Konversation aus der Benutzerliste.";
+"Choose a conversation from the filtered results." = "Wähle eine Konversation aus den gefilterten Ergebnissen.";
+"Try another search." = "Versuche eine andere Suche.";
+"No broadcast permission" = "Keine Broadcast-Berechtigung";
+"User unavailable" = "Benutzer nicht verfügbar";
+"Broadcast message required…" = "Broadcast-Nachricht erforderlich…";
+"Broadcast to all online users…" = "An alle Online-Benutzer senden…";
+"Type message here…" = "Nachricht hier eingeben…";
+
+/* ── Smart Board Editor ── */
+"New Smart Board" = "Neues Smart Board";
+"Edit Smart Board" = "Smart Board bearbeiten";
+"Name:" = "Name:";
+"Thread Filters" = "Thread-Filter";
+"Board:" = "Board:";
+"All Boards" = "Alle Boards";
+"Subject:" = "Betreff:";
+"Reply:" = "Antwort:";
+"Nick:" = "Nick:";
+"Unread:" = "Ungelesen:";
+"Yes" = "Ja";
+
+/* ── Markdown Composer ── */
+"Bold" = "Fett";
+"Italic" = "Kursiv";
+"Inline Code" = "Inline-Code";
+"Link" = "Link";
+"Quote" = "Zitat";
+"List" = "Liste";
+"Preview" = "Vorschau";
+"Nothing to preview" = "Nichts zu zeigen";
+
+/* ── Transfers ── */
+"Remove transfer?" = "Übertragung entfernen?";
+"Remove Transfers" = "Übertragungen entfernen";
+"Remove Transfer" = "Übertragung entfernen";
+"Are you sure you want to remove this transfer?" = "Möchten Sie diese Übertragung wirklich entfernen?";
+"Clear finished transfers" = "Abgeschlossene Übertragungen leeren";
+"Show in Finder" = "Im Finder anzeigen";
+"Show Remote Location" = "Entfernten Speicherort anzeigen";
+"Unknown Server" = "Unbekannter Server";
+
+/* ── Files ── */
+"Unable to download \"%@\":\n%@" = "„%@\" kann nicht heruntergeladen werden:\n%@";
+
+/* ── Sort / Boards ── */
+"Sort threads" = "Threads sortieren";
+"Ascending" = "Aufsteigend";
+"Descending" = "Absteigend";
+
+/* ── User actions (kick/ban sheet) ── */
+"Expire" = "Ablaufen";
+"Expiration date" = "Ablaufdatum";
+
+/* ── Boards permissions ── */
+"None" = "Keine";
+"Owner" = "Eigentümer";
+"Owner access" = "Eigentümerzugriff";
+"Group access" = "Gruppenzugriff";
+
+/* ── Server Settings – Allgemein/Protokoll-Tabs ── */
+"General" = "Allgemein";
+"Log" = "Protokoll";
+"KB/s" = "KB/s";
+"bytes" = "Bytes";
+"Unlimited" = "Unbegrenzt";
+"0 = unlimited" = "0 = unbegrenzt";
+"Effective Mode" = "Effektiver Modus";
+"Auto-reconnecting..." = "Verbinde automatisch...";
+
+/* ── Konten – Detailfelder ── */
+"Identity" = "Identität";
+"Created" = "Erstellt";
+"Modified" = "Geändert";
+"Last Login" = "Letzter Login";
+"Modified By" = "Geändert von";
+"Downloads" = "Downloads";
+"Uploads" = "Uploads";
+"Add User" = "Benutzer hinzufügen";
+"Add Group" = "Gruppe hinzufügen";
+"Initial password" = "Initiales Passwort";
+
+/* ── Konten – Berechtigungskategorien ── */
+"Basic" = "Grundlegend";
+"Administration" = "Administration";
+"Limits" = "Limits";
+"Other" = "Sonstiges";
+"Color" = "Farbe";
+"Black" = "Schwarz";
+"Red" = "Rot";
+"Orange" = "Orange";
+"Green" = "Grün";
+"Blue" = "Blau";
+"Purple" = "Lila";
+
+/* ── Server-Info-Tab ── */
+"Application" = "Anwendung";
+"Version" = "Version";
+"System" = "System";
+"OS" = "Betriebssystem";
+"Architecture" = "Architektur";
+"Count" = "Anzahl";
+"Uptime" = "Laufzeit";
+"Loading server information…" = "Serverinformationen werden geladen…";
+"Verified Identity" = "Verifizierte Identität";
+"Identity not verified" = "Identität nicht verifiziert";
+
+/* ── Dateiinfo-Fenster ── */
+"File Info" = "Dateiinfo";
+"Close" = "Schließen";
+"Metadata" = "Metadaten";
+"Label" = "Beschriftung";
+"Data" = "Daten";
+"Resource" = "Ressource";
+"Total" = "Gesamt";
+"Folder" = "Ordner";
+"Contains" = "Enthält";
+"Folder Permissions" = "Ordner-Berechtigungen";
+"Access" = "Zugriff";
+"Everyone" = "Alle";
+"Sync Policy" = "Sync-Richtlinie";
+"Max File Size" = "Maximale Dateigröße";
+"Max Tree Size" = "Maximale Verzeichnisgröße";
+"Exclude Patterns" = "Ausschlussmuster";
+"Quota" = "Kontingent";
+"No Access" = "Kein Zugriff";
+"Read & Write" = "Lesen und Schreiben";
+"Read Only" = "Nur lesen";
+"Write Only" = "Nur schreiben";
+"Disabled" = "Deaktiviert";
+"Server → Client" = "Server → Client";
+"Client → Server" = "Client → Server";
+"Bidirectional" = "Bidirektional";
+
+/* ── App-Einstellungen ── */
+"Icon" = "Symbol";
+"Choose..." = "Auswählen…";
+"Nickname" = "Spitzname";
+"Find" = "Suchen";
+"About Wired 3" = "Über Wired 3";
+"Settings..." = "Einstellungen…";
+
+/* ── Berechtigungskategorie ── */
+"Transfers" = "Übertragungen";
+
+/* ── Übertragungen – Tooltips ── */
+"Play transfer" = "Übertragung starten";
+"Pause transfer" = "Übertragung pausieren";
+"Stop transfer" = "Übertragung stoppen";
+"Remove transfer" = "Übertragung entfernen";
+
+/* ── Dateien ── */
+"Create Directory" = "Ordner erstellen";
+"Delete File" = "Datei löschen";
+"Delete Files" = "Dateien löschen";
+"Are you sure you want to delete this file? This operation is not recoverable." = "Möchten Sie diese Datei wirklich löschen? Diese Aktion kann nicht rückgängig gemacht werden.";
+"Are you sure you want to delete this selection? This operation is not recoverable." = "Möchten Sie diese Auswahl wirklich löschen? Diese Aktion kann nicht rückgängig gemacht werden.";
+"Upload Blocked" = "Upload blockiert";
+"Searching…" = "Suche läuft…";
+
+/* ── Synchronisation ── */
+"Deactivate Sync Pair" = "Synchronisierungspaar deaktivieren";
+"Sync Error" = "Sync-Fehler";
+"Sync Enabled" = "Sync aktiviert";
+"Sync Triggered" = "Sync ausgelöst";
+"Sync Already Running" = "Sync läuft bereits";
+"Sync Disabled" = "Sync deaktiviert";
+"Your account is not allowed to activate sync pairs." = "Ihr Konto darf keine Synchronisierungspaare aktivieren.";
+"No active Wired connection available for sync activation." = "Keine aktive Wired-Verbindung für die Sync-Aktivierung verfügbar.";
+"The selected sync folder is disabled for your account." = "Der gewählte Sync-Ordner ist für Ihr Konto deaktiviert.";
+"No active Wired connection available for sync deactivation." = "Keine aktive Wired-Verbindung für die Sync-Deaktivierung verfügbar.";
+
+/* ── Einstellungs-Tabs ── */
+"Chat" = "Chat";
+"Behavior" = "Verhalten";
+"Check for active connections before closing" = "Vor dem Schließen auf aktive Verbindungen prüfen";
+"Timestamp in Chats and Messages" = "Zeitstempel in Chats und Nachrichten";
+"Every (min.)" = "Alle (Min.)";
+"Messages displayed" = "Angezeigte Nachrichten";
+"Timestamp every message" = "Jede Nachricht mit Zeitstempel";
+"Emoji" = "Emoji";
+"Substitute Emoji" = "Emoji ersetzen";
+"Emoji Substitutions" = "Emoji-Ersetzungen";
+"History" = "Verlauf";
+"Archive Chat Messages" = "Chat-Nachrichten archivieren";
+"When enabled, chat messages are saved locally for later browsing in Chat History." = "Wenn aktiviert, werden Chat-Nachrichten lokal gespeichert und können später im Chat-Verlauf angezeigt werden.";
+"Highlights" = "Hervorhebungen";
+"No highlights yet." = "Noch keine Hervorhebungen.";
+"Keyword" = "Schlüsselwort";
+"Delete Highlight?" = "Hervorhebung löschen?";
+"This highlight has no keyword. Do you want to delete it?" = "Diese Hervorhebung hat kein Schlüsselwort. Möchten Sie sie löschen?";
+"Do you want to delete the highlight for \"%@\"?" = "Möchten Sie die Hervorhebung für \"%@\" löschen?";
+"Do you want to delete this highlight?" = "Möchten Sie diese Hervorhebung löschen?";
+"No emoji substitutions yet." = "Noch keine Emoji-Ersetzungen.";
+"Code" = "Code";
+"Delete Emoji Substitution?" = "Emoji-Ersetzung löschen?";
+"Do you want to delete this emoji substitution?" = "Möchten Sie diese Emoji-Ersetzung löschen?";
+"Add Highlight" = "Hervorhebung hinzufügen";
+"Add Substitution" = "Ersetzung hinzufügen";
+"Back" = "Zurück";
+"Download Folder" = "Download-Ordner";
+"Volume" = "Lautstärke";
+"Event Configuration" = "Ereigniskonfiguration";
+"Sound" = "Ton";
+"Bounce in Dock" = "Im Dock springen";
+"Post in Chat" = "Im Chat posten";
+"Alert" = "Hinweis";
+"Notification" = "Benachrichtigung";
+"Events settings table is available on macOS." = "Die Ereignistabelle ist auf macOS verfügbar.";
+"Activity" = "Aktivität";
+"Filter errors" = "Fehler filtern";
+"No Errors" = "Keine Fehler";
+"No logged errors for the current filter." = "Keine Fehler für den aktuellen Filter protokolliert.";
+"Clear" = "Leeren";
+
+/* ── Menübefehle ── */
+"No Bookmarks" = "Keine Lesezeichen";
+"Window Tab for Bookmark" = "Fenster-Tab für Lesezeichen";
+"New Tab for Bookmark" = "Neuer Tab für Lesezeichen";
+"Reconnect" = "Erneut verbinden";
+"Show Server Info" = "Serverinfo anzeigen";
+"Set Topic" = "Thema festlegen";
+"New Broadcast" = "Neue Rundsendung";
+"Change password..." = "Passwort ändern...";
+
+/* ── Beenden-/Schließen-Dialoge ── */
+"Active connections and transfers" = "Aktive Verbindungen und Übertragungen";
+"There are %lld active connections and active transfers. Quitting now will stop transfers." = "Es gibt %lld aktive Verbindungen und laufende Übertragungen. Beim Beenden werden die Übertragungen gestoppt.";
+"Disconnect and Quit" = "Trennen und beenden";
+"Active connection" = "Aktive Verbindung";
+"Active connections" = "Aktive Verbindungen";
+"Do you want to disconnect the active connection before quitting?" = "Möchten Sie die aktive Verbindung vor dem Beenden trennen?";
+"Do you want to disconnect %lld active connections before quitting?" = "Möchten Sie %lld aktive Verbindungen vor dem Beenden trennen?";
+"Active transfers are in progress." = "Aktive Übertragungen sind im Gange.";
+"Quitting now will stop active transfers." = "Beim Beenden werden aktive Übertragungen gestoppt.";
+"Quit Anyway" = "Trotzdem beenden";
+"Do you want to disconnect the active connection before closing this window/tab?" = "Möchten Sie die aktive Verbindung vor dem Schließen dieses Fensters/Tabs trennen?";
+"Do you want to disconnect %lld active connections before closing this window/tab?" = "Möchten Sie %lld aktive Verbindungen vor dem Schließen dieses Fensters/Tabs trennen?";
+
+/* ── Fenster ── */
+"Error Log" = "Fehlerprotokoll";
+"Chat History" = "Chat-Verlauf";
+
+/* ── Seitenleiste / Hauptansicht ── */
+"Delete Bookmark" = "Lesezeichen löschen";
+"Delete Tracker" = "Tracker löschen";
+"Show Transfers" = "Übertragungen anzeigen";
+"About Wired 3" = "Über Wired 3";
+
+/* ── Passwort ändern ── */
+"New password" = "Neues Passwort";
+"Confirm password" = "Passwort bestätigen";
+"Change" = "Ändern";
+"Your account was migrated from Wired 2.5. You must set a new password before you can use this server." = "Ihr Konto wurde von Wired 2.5 migriert. Sie müssen ein neues Passwort festlegen, bevor Sie diesen Server verwenden können.";
+"No active connection." = "Keine aktive Verbindung.";
+"Server error." = "Serverfehler.";
+
+/* ── Boards ── */
+"Mark as Read" = "Als gelesen markieren";
+"Mark as Unread" = "Als ungelesen markieren";
+"Mark as read" = "Als gelesen markieren";
+"Mark as unread" = "Als ungelesen markieren";
+"Loading boards…" = "Boards werden geladen…";
+"No Boards" = "Keine Boards";
+"No Smart Boards" = "Keine Smart Boards";
+"SMART BOARDS" = "SMART BOARDS";
+"BOARDS" = "BOARDS";
+"Delete Smart Board" = "Smart Board löschen";
+"Rename Board" = "Board umbenennen";
+"Edit Permissions" = "Berechtigungen bearbeiten";
+"Move Board" = "Board verschieben";
+"Delete Board" = "Board löschen";
+"New Board" = "Neues Board";
+"Boards network activity" = "Boards-Netzwerkaktivität";
+"Mark all as read" = "Alle als gelesen markieren";
+"No Matching Threads" = "Keine übereinstimmenden Themen";
+"Searching boards…" = "Boards werden durchsucht…";
+"No Search Results" = "Keine Suchergebnisse";
+"Loading threads…" = "Themen werden geladen…";
+"No Threads" = "Keine Themen";
+"Select a Board" = "Board auswählen";
+"Select a Thread" = "Thema auswählen";
+"New" = "Neu";
+"Reply" = "Antworten";
+"Edit Thread" = "Thema bearbeiten";
+"Move Thread" = "Thema verschieben";
+"Delete Thread" = "Thema löschen";
+"Reveal in Board" = "Im Board anzeigen";
+"Delete board?" = "Board löschen?";
+"Delete smart board?" = "Smart Board löschen?";
+"Delete thread?" = "Thema löschen?";
+"Threads" = "Themen";
+"Posts" = "Beiträge";
+"New Thread" = "Neues Thema";
+"Subject" = "Betreff";
+"Post" = "Posten";
+"Re: %@" = "Re: %@";
+
+/* ── Board-Sheets ── */
+"Board Permissions" = "Board-Berechtigungen";
+"Board" = "Board";
+"Loading permissions…" = "Berechtigungen werden geladen…";
+"Loading accounts…" = "Konten werden geladen…";
+"Path" = "Pfad";
+"Current" = "Aktuell";
+"Rename" = "Umbenennen";
+"Move" = "Verschieben";
+"Destination Path" = "Zielpfad";
+"Destination" = "Ziel";
+"Board Name" = "Board-Name";
+"Location" = "Ort";
+"Parent" = "Übergeordnet";
+
+/* ── Berechtigungsanzeigenamen (wired.account.*) ── */
+"wired.account.color" = "Farbe";
+"wired.account.login" = "Anmeldung";
+"wired.account.nick" = "Spitzname";
+"wired.account.create_accounts" = "Konten erstellen";
+"wired.account.delete_accounts" = "Konten löschen";
+"wired.account.read_accounts" = "Konten lesen";
+"wired.account.modify_accounts" = "Konten bearbeiten";
+"wired.account.alter_password" = "Passwort ändern";
+"wired.account.read_groups" = "Gruppen lesen";
+"wired.account.create_groups" = "Gruppen erstellen";
+"wired.account.delete_groups" = "Gruppen löschen";
+"wired.account.modify_groups" = "Gruppen bearbeiten";
+"wired.account.file.list_files" = "Dateien auflisten";
+"wired.account.file.search" = "Suchen";
+"wired.account.file.get_info" = "Infos abrufen";
+"wired.account.file.create_directories" = "Ordner erstellen";
+"wired.account.file.create_links" = "Links erstellen";
+"wired.account.file.move_files" = "Dateien verschieben";
+"wired.account.file.rename_files" = "Dateien umbenennen";
+"wired.account.file.set_type" = "Typ festlegen";
+"wired.account.file.set_comment" = "Kommentar festlegen";
+"wired.account.file.set_permissions" = "Berechtigungen festlegen";
+"wired.account.file.set_label" = "Beschriftung festlegen";
+"wired.account.file.delete_files" = "Dateien löschen";
+"wired.account.file.access_all_dropboxes" = "Alle Ablagefächer öffnen";
+"wired.account.file.set_aliases" = "Aliase festlegen";
+"wired.account.file.recursive_list_files" = "Dateien rekursiv auflisten";
+"wired.account.user.get_users" = "Benutzer abrufen";
+"wired.account.user.get_info" = "Benutzerinfos abrufen";
+"wired.account.user.disconnect_users" = "Benutzer trennen";
+"wired.account.user.kick_users" = "Benutzer rauswerfen";
+"wired.account.user.ban_users" = "Benutzer sperren";
+"wired.account.user.cannot_be_disconnected" = "Kann nicht getrennt werden";
+"wired.account.user.list_offline_users" = "Offline-Benutzer auflisten";
+"wired.account.transfer.download_files" = "Dateien herunterladen";
+"wired.account.transfer.upload_files" = "Dateien hochladen";
+"wired.account.transfer.upload_anywhere" = "Überall hochladen";
+"wired.account.transfer.upload_directories" = "Ordner hochladen";
+"wired.account.transfer.download_limit" = "Download-Limit";
+"wired.account.transfer.upload_limit" = "Upload-Limit";
+"wired.account.message.send_messages" = "Nachrichten senden";
+"wired.account.message.broadcast" = "Rundsendung";
+"wired.account.board.read_boards" = "Boards lesen";
+"wired.account.board.add_boards" = "Boards hinzufügen";
+"wired.account.board.move_boards" = "Boards verschieben";
+"wired.account.board.rename_boards" = "Boards umbenennen";
+"wired.account.board.delete_boards" = "Boards löschen";
+"wired.account.board.get_board_info" = "Board-Infos abrufen";
+"wired.account.board.set_board_info" = "Board-Infos festlegen";
+"wired.account.board.add_threads" = "Themen hinzufügen";
+"wired.account.board.move_threads" = "Themen verschieben";
+"wired.account.board.delete_all_threads_and_posts" = "Alle Themen und Beiträge löschen";
+"wired.account.board.delete_own_threads_and_posts" = "Eigene Themen und Beiträge löschen";
+"wired.account.board.edit_all_threads_and_posts" = "Alle Themen und Beiträge bearbeiten";
+"wired.account.board.edit_own_threads_and_posts" = "Eigene Themen und Beiträge bearbeiten";
+"wired.account.board.add_posts" = "Beiträge hinzufügen";
+"wired.account.board.delete_all_posts" = "Alle Beiträge löschen";
+"wired.account.board.edit_own_posts" = "Eigene Beiträge bearbeiten";
+"wired.account.board.search_boards" = "Boards durchsuchen";
+"wired.account.administration.take_screenshots" = "Screenshots aufnehmen";
+"wired.account.administration.rename_server" = "Server umbenennen";
+"wired.account.administration.send_serverinfo" = "Server-Infos senden";
+"wired.account.administration.get_server_info" = "Server-Infos abrufen";
+"wired.account.administration.set_server_banner" = "Server-Banner festlegen";
+"wired.account.tracker.list_servers" = "Server auflisten";
+"wired.account.tracker.register_servers" = "Server registrieren";
+"wired.account.banlist.get_bans" = "Sperren abrufen";
+"wired.account.banlist.add_bans" = "Sperren hinzufügen";
+"wired.account.banlist.delete_bans" = "Sperren löschen";
+
+/* ── File preview panel ── */
+"No Selection" = "Keine Auswahl";
+"Executable" = "Ausführbar";
+"1 item" = "1 Element";
+"%lld items" = "%lld Elemente";
+"Sync Pair" = "Sync-Paarung";
+"Pair" = "Paarung";
+"Active" = "Aktiv";
+"Inactive" = "Inaktiv";
+"Mode" = "Modus";
+"Checking…" = "Prüfe…";
+"Paused" = "Pausiert";
+"Syncing…" = "Synchronisiere…";
+"Reconnecting" = "Verbinde erneut";
+"Error" = "Fehler";
+
+/* ── Chat privileges ── */
+"wired.account.chat.kick_users" = "Benutzer aus Chat entfernen";
+"wired.account.chat.set_topic" = "Thema festlegen";
+"wired.account.chat.create_chats" = "Chats erstellen";
+"wired.account.chat.create_public_chats" = "Öffentliche Chats erstellen";
+"wired.account.chat.delete_public_chats" = "Öffentliche Chats löschen";
+
+/* ── User privileges (additions) ── */
+"wired.account.user.cannot_set_nick" = "Kann Spitzname nicht ändern";
+
+/* ── Message privileges (additions) ── */
+"wired.account.message.send_offline_messages" = "Offline-Nachrichten senden";
+
+/* ── Board privileges (additions) ── */
+"wired.account.board.add_reactions" = "Reaktionen hinzufügen";
+
+/* ── File privileges (additions) ── */
+"wired.account.file.search_files" = "Dateien suchen";
+"wired.account.file.set_executable" = "Als ausführbar markieren";
+"wired.account.file.recursive_list_depth_limit" = "Rekursive Listen-Tiefe";
+"wired.account.file.sync.sync_files" = "Dateien synchronisieren";
+"wired.account.file.sync.delete_remote" = "Remote-Dateien löschen";
+
+/* ── Transfer privileges (additions) ── */
+"wired.account.transfer.download_speed_limit" = "Download-Geschwindigkeitslimit";
+"wired.account.transfer.upload_speed_limit" = "Upload-Geschwindigkeitslimit";
+
+/* ── Attachment privileges ── */
+"wired.account.attachment.upload" = "Anhänge hochladen";
+
+/* ── Account management privileges ── */
+"wired.account.account.change_password" = "Passwort ändern";
+"wired.account.account.list_accounts" = "Konten auflisten";
+"wired.account.account.read_accounts" = "Konten lesen";
+"wired.account.account.create_users" = "Benutzer erstellen";
+"wired.account.account.edit_users" = "Benutzer bearbeiten";
+"wired.account.account.delete_users" = "Benutzer löschen";
+"wired.account.account.create_groups" = "Gruppen erstellen";
+"wired.account.account.edit_groups" = "Gruppen bearbeiten";
+"wired.account.account.delete_groups" = "Gruppen löschen";
+"wired.account.account.raise_account_privileges" = "Berechtigungen erhöhen";
+
+/* ── Log / Events / Settings privileges ── */
+"wired.account.log.view_log" = "Protokoll anzeigen";
+"wired.account.events.view_events" = "Ereignisse anzeigen";
+"wired.account.settings.get_settings" = "Einstellungen lesen";
+"wired.account.settings.set_settings" = "Einstellungen schreiben";
+
+/* ── Files toolbar ── */
+"Display Mode" = "Ansicht";
+"Navigate Backward" = "Zurück navigieren";
+"Navigate Forward" = "Vorwärts navigieren";
+"Reload Files" = "Dateien neu laden";
+"Download File(s)" = "Datei(en) herunterladen";
+"Upload File(s)" = "Datei(en) hochladen";
+"Create Folder" = "Ordner erstellen";
+"Delete File(s)" = "Datei(en) löschen";
+
+/* ── Files overwrite alert ── */
+"File Already Exists" = "Datei existiert bereits";
+"A file already exists at:\n%@\n\nOverwrite it?" = "Eine Datei existiert bereits unter:\n%@\n\nÜberschreiben?";
+"Overwrite" = "Überschreiben";
+
+/* ── Files column headers ── */
+"Kind" = "Art";
+
+/* ── Files context menu ── */
+"Quick Look" = "Schnellansicht";
+"New Folder" = "Neuer Ordner";
+"Upload…" = "Hochladen…";
+
+/* ── Sync context menu ── */
+"Activate Sync Pair" = "Sync-Paarung aktivieren";
+"Sync Now" = "Jetzt synchronisieren";
+"Sync Status: Pair inactive" = "Sync-Status: Paarung inaktiv";
+"Sync Status: Paused" = "Sync-Status: Pausiert";
+"Sync Status: Connecting…" = "Sync-Status: Verbinde…";
+"Sync Status: Connected" = "Sync-Status: Verbunden";
+"Sync Status: Syncing…" = "Sync-Status: Synchronisiere…";
+"Sync Status: Reconnecting…" = "Sync-Status: Verbinde erneut…";
+"Sync Status: Updating…" = "Sync-Status: Aktualisiere…";
+
+/* ── Sync tooltips ── */
+"Sync status pending" = "Sync-Status ausstehend";
+"Sync paused" = "Sync pausiert";
+"Sync in progress" = "Sync läuft";
+"Sync reconnecting" = "Sync verbindet erneut";
+"Sync connected" = "Sync verbunden";
+"Sync error" = "Sync-Fehler";
+"Sync inactive" = "Sync inaktiv";

--- a/Wired 3/de.lproj/Localizable.strings
+++ b/Wired 3/de.lproj/Localizable.strings
@@ -650,7 +650,15 @@
 /* ── Files overwrite alert ── */
 "File Already Exists" = "Datei existiert bereits";
 "A file already exists at:\n%@\n\nOverwrite it?" = "Eine Datei existiert bereits unter:\n%@\n\nÜberschreiben?";
+"Do you want to overwrite \"%@\"?" = "Möchten Sie „%@" überschreiben?";
 "Overwrite" = "Überschreiben";
+
+/* ── Quick Look alert ── */
+"Download Preview?" = "Vorschau laden?";
+"Download Previews?" = "Vorschauen laden?";
+"%@ is not cached yet and is larger than 512 KB.\nWired will fetch a lightweight Quick Look preview from the server." = "%@ ist noch nicht zwischengespeichert und größer als 512 KB.\nWired lädt eine schlanke Schnellansicht vom Server.";
+"%lld selected files are not cached yet and are larger than 512 KB.\nWired will fetch lightweight Quick Look previews from the server." = "%lld ausgewählte Dateien sind noch nicht zwischengespeichert und größer als 512 KB.\nWired lädt schlanke Schnellansichten vom Server.";
+"Quick Look Error" = "Schnellansicht-Fehler";
 
 /* ── Files column headers ── */
 "Kind" = "Art";

--- a/Wired 3/de.lproj/Localizable.strings
+++ b/Wired 3/de.lproj/Localizable.strings
@@ -443,7 +443,6 @@
 "Delete Bookmark" = "Lesezeichen löschen";
 "Delete Tracker" = "Tracker löschen";
 "Show Transfers" = "Übertragungen anzeigen";
-"About Wired 3" = "Über Wired 3";
 
 /* ── Passwort ändern ── */
 "New password" = "Neues Passwort";
@@ -657,7 +656,7 @@
 /* ── Files overwrite alert ── */
 "File Already Exists" = "Datei existiert bereits";
 "A file already exists at:\n%@\n\nOverwrite it?" = "Eine Datei existiert bereits unter:\n%@\n\nÜberschreiben?";
-"Do you want to overwrite \"%@\"?" = "Möchten Sie „%@" überschreiben?";
+"Do you want to overwrite \"%@\"?" = "Möchten Sie \"%@\" überschreiben?";
 "Overwrite" = "Überschreiben";
 
 /* ── Quick Look alert ── */

--- a/Wired 3/de.lproj/Localizable.strings
+++ b/Wired 3/de.lproj/Localizable.strings
@@ -296,6 +296,13 @@
 "Verified Identity" = "Verifizierte Identität";
 "Identity not verified" = "Identität nicht verifiziert";
 
+/* ── Dateitypen ── */
+"File" = "Datei";
+"Directory" = "Ordner";
+"Uploads Folder" = "Upload-Ordner";
+"Drop Box" = "Ablagebox";
+"Sync Folder" = "Synchronisierungsordner";
+
 /* ── Dateiinfo-Fenster ── */
 "File Info" = "Dateiinfo";
 "Close" = "Schließen";

--- a/Wired 3/en.lproj/Localizable.strings
+++ b/Wired 3/en.lproj/Localizable.strings
@@ -34,6 +34,17 @@
 "Never" = "Never";
 "Date" = "Date";
 "Category" = "Category";
+"No" = "No";
+"Edit" = "Edit";
+"Remove" = "Remove";
+"Start" = "Start";
+"Pause" = "Pause";
+"Stop" = "Stop";
+"Size" = "Size";
+"Description" = "Description";
+"URL" = "URL";
+"Status" = "Status";
+"Info" = "Info";
 
 /* ── Monitor view ── */
 "Access Denied" = "Access Denied";
@@ -62,6 +73,34 @@
 "DL Speed" = "DL Speed";
 "Concurrent Uploads" = "Concurrent Uploads";
 "UL Speed" = "UL Speed";
+
+/* ── Navigation ── */
+"Favorites" = "Favorites";
+"Connections" = "Connections";
+"Trackers" = "Trackers";
+"Add Tracker" = "Add Tracker";
+"New Connection" = "New Connection";
+"Select an item" = "Select an item";
+"Chats" = "Chats";
+"Messages" = "Messages";
+"Boards" = "Boards";
+"Files" = "Files";
+"Bookmark" = "Bookmark";
+"Connect" = "Connect";
+"Tracker" = "Tracker";
+"Loading tracker…" = "Loading tracker…";
+"No servers listed" = "No servers listed";
+"Get Info" = "Get Info";
+"Add to Favorites" = "Add to Favorites";
+"Add to Trackers" = "Add to Trackers";
+"Connection" = "Connection";
+
+/* ── Connection state ── */
+"Connecting…" = "Connecting…";
+"Disconnected" = "Disconnected";
+"Connection unavailable" = "Connection unavailable";
+"Are you sure you want to disconnect from this server?" = "Are you sure you want to disconnect from this server?";
+"Disconnect and Close" = "Disconnect and Close";
 
 /* ── Tracker / Directory ── */
 "Each directory is registered as a `wired://host[:port]/Category` URL. The interface edits the parts and serializes them automatically." = "Each directory is registered as a `wired://host[:port]/Category` URL. The interface edits the parts and serializes them automatically.";
@@ -119,6 +158,48 @@
 "Comma-separated" = "Comma-separated";
 "Example: staff, moderators" = "Example: staff, moderators";
 
+/* ── Chat / User list ── */
+"Online" = "Online";
+"Offline" = "Offline";
+"Get Infos" = "Get Infos";
+"Send Private Message" = "Send Private Message";
+"Invite to Private Chat" = "Invite to Private Chat";
+"Kick" = "Kick";
+"Ban" = "Ban";
+"Kick User" = "Kick User";
+"Ban User" = "Ban User";
+"Chat here…" = "Chat here…";
+"Add a message or press Return to send…" = "Add a message or press Return to send…";
+
+/* ── User info panel ── */
+"App version" = "App version";
+"P7 Protocol" = "P7 Protocol";
+"Wired Protocol" = "Wired Protocol";
+"OS Name" = "OS Name";
+"OS Version" = "OS Version";
+"Arch" = "Arch";
+"IP Address" = "IP Address";
+"Hostname" = "Hostname";
+"Cipher" = "Cipher";
+"Login Time" = "Login Time";
+"Idle Time" = "Idle Time";
+"Transfer" = "Transfer";
+
+/* ── Messages ── */
+"Private Messages" = "Private Messages";
+"Broadcasts" = "Broadcasts";
+"No Results" = "No Results";
+"Select a Conversation" = "Select a Conversation";
+"No Conversation" = "No Conversation";
+"Open a conversation from the users list." = "Open a conversation from the users list.";
+"Choose a conversation from the filtered results." = "Choose a conversation from the filtered results.";
+"Try another search." = "Try another search.";
+"No broadcast permission" = "No broadcast permission";
+"User unavailable" = "User unavailable";
+"Broadcast message required…" = "Broadcast message required…";
+"Broadcast to all online users…" = "Broadcast to all online users…";
+"Type message here…" = "Type message here…";
+
 /* ── Smart Board Editor ── */
 "New Smart Board" = "New Smart Board";
 "Edit Smart Board" = "Edit Smart Board";
@@ -143,6 +224,16 @@
 "Preview" = "Preview";
 "Nothing to preview" = "Nothing to preview";
 
+/* ── Transfers ── */
+"Remove transfer?" = "Remove transfer?";
+"Remove Transfers" = "Remove Transfers";
+"Remove Transfer" = "Remove Transfer";
+"Are you sure you want to remove this transfer?" = "Are you sure you want to remove this transfer?";
+"Clear finished transfers" = "Clear finished transfers";
+"Show in Finder" = "Show in Finder";
+"Show Remote Location" = "Show Remote Location";
+"Unknown Server" = "Unknown Server";
+
 /* ── Files ── */
 "Unable to download \"%@\":\n%@" = "Unable to download \"%@\":\n%@";
 
@@ -160,3 +251,433 @@
 "Owner" = "Owner";
 "Owner access" = "Owner access";
 "Group access" = "Group access";
+
+/* ── Server Settings – General/Log tabs ── */
+"General" = "General";
+"Log" = "Log";
+"KB/s" = "KB/s";
+"bytes" = "bytes";
+"Unlimited" = "Unlimited";
+"0 = unlimited" = "0 = unlimited";
+"Effective Mode" = "Effective Mode";
+"Auto-reconnecting..." = "Auto-reconnecting...";
+
+/* ── Accounts – detail fields ── */
+"Identity" = "Identity";
+"Created" = "Created";
+"Modified" = "Modified";
+"Last Login" = "Last Login";
+"Modified By" = "Modified By";
+"Downloads" = "Downloads";
+"Uploads" = "Uploads";
+"Add User" = "Add User";
+"Add Group" = "Add Group";
+"Initial password" = "Initial password";
+
+/* ── Accounts – permission categories ── */
+"Basic" = "Basic";
+"Administration" = "Administration";
+"Limits" = "Limits";
+"Other" = "Other";
+"Color" = "Color";
+"Black" = "Black";
+"Red" = "Red";
+"Orange" = "Orange";
+"Green" = "Green";
+"Blue" = "Blue";
+"Purple" = "Purple";
+
+/* ── Server Info tab ── */
+"Application" = "Application";
+"Version" = "Version";
+"System" = "System";
+"OS" = "OS";
+"Architecture" = "Architecture";
+"Count" = "Count";
+"Uptime" = "Uptime";
+"Loading server information…" = "Loading server information…";
+"Verified Identity" = "Verified Identity";
+"Identity not verified" = "Identity not verified";
+
+/* ── File Info sheet ── */
+"File Info" = "File Info";
+"Close" = "Close";
+"Metadata" = "Metadata";
+"Label" = "Label";
+"Data" = "Data";
+"Resource" = "Resource";
+"Total" = "Total";
+"Folder" = "Folder";
+"Contains" = "Contains";
+"Folder Permissions" = "Folder Permissions";
+"Access" = "Access";
+"Everyone" = "Everyone";
+"Sync Policy" = "Sync Policy";
+"Max File Size" = "Max File Size";
+"Max Tree Size" = "Max Tree Size";
+"Exclude Patterns" = "Exclude Patterns";
+"Quota" = "Quota";
+"No Access" = "No Access";
+"Read & Write" = "Read & Write";
+"Read Only" = "Read Only";
+"Write Only" = "Write Only";
+"Disabled" = "Disabled";
+"Server → Client" = "Server → Client";
+"Client → Server" = "Client → Server";
+"Bidirectional" = "Bidirectional";
+
+/* ── App settings ── */
+"Icon" = "Icon";
+"Choose..." = "Choose...";
+"Nickname" = "Nickname";
+"Find" = "Find";
+"About Wired 3" = "About Wired 3";
+"Settings..." = "Settings...";
+
+/* ── Permission category ── */
+"Transfers" = "Transfers";
+
+/* ── Transfers – tooltips ── */
+"Play transfer" = "Play transfer";
+"Pause transfer" = "Pause transfer";
+"Stop transfer" = "Stop transfer";
+"Remove transfer" = "Remove transfer";
+
+/* ── Files ── */
+"Create Directory" = "Create Directory";
+"Delete File" = "Delete File";
+"Delete Files" = "Delete Files";
+"Are you sure you want to delete this file? This operation is not recoverable." = "Are you sure you want to delete this file? This operation is not recoverable.";
+"Are you sure you want to delete this selection? This operation is not recoverable." = "Are you sure you want to delete this selection? This operation is not recoverable.";
+"Upload Blocked" = "Upload Blocked";
+"Searching…" = "Searching…";
+
+/* ── Sync ── */
+"Deactivate Sync Pair" = "Deactivate Sync Pair";
+"Sync Error" = "Sync Error";
+"Sync Enabled" = "Sync Enabled";
+"Sync Triggered" = "Sync Triggered";
+"Sync Already Running" = "Sync Already Running";
+"Sync Disabled" = "Sync Disabled";
+"Your account is not allowed to activate sync pairs." = "Your account is not allowed to activate sync pairs.";
+"No active Wired connection available for sync activation." = "No active Wired connection available for sync activation.";
+"The selected sync folder is disabled for your account." = "The selected sync folder is disabled for your account.";
+"No active Wired connection available for sync deactivation." = "No active Wired connection available for sync deactivation.";
+
+/* ── Settings panes ── */
+"Chat" = "Chat";
+"Behavior" = "Behavior";
+"Check for active connections before closing" = "Check for active connections before closing";
+"Timestamp in Chats and Messages" = "Timestamp in Chats and Messages";
+"Every (min.)" = "Every (min.)";
+"Messages displayed" = "Messages displayed";
+"Timestamp every message" = "Timestamp every message";
+"Emoji" = "Emoji";
+"Substitute Emoji" = "Substitute Emoji";
+"Emoji Substitutions" = "Emoji Substitutions";
+"History" = "History";
+"Archive Chat Messages" = "Archive Chat Messages";
+"When enabled, chat messages are saved locally for later browsing in Chat History." = "When enabled, chat messages are saved locally for later browsing in Chat History.";
+"Highlights" = "Highlights";
+"No highlights yet." = "No highlights yet.";
+"Keyword" = "Keyword";
+"Delete Highlight?" = "Delete Highlight?";
+"This highlight has no keyword. Do you want to delete it?" = "This highlight has no keyword. Do you want to delete it?";
+"Do you want to delete the highlight for \"%@\"?" = "Do you want to delete the highlight for \"%@\"?";
+"Do you want to delete this highlight?" = "Do you want to delete this highlight?";
+"No emoji substitutions yet." = "No emoji substitutions yet.";
+"Code" = "Code";
+"Delete Emoji Substitution?" = "Delete Emoji Substitution?";
+"Do you want to delete this emoji substitution?" = "Do you want to delete this emoji substitution?";
+"Add Highlight" = "Add Highlight";
+"Add Substitution" = "Add Substitution";
+"Back" = "Back";
+"Download Folder" = "Download Folder";
+"Volume" = "Volume";
+"Event Configuration" = "Event Configuration";
+"Sound" = "Sound";
+"Bounce in Dock" = "Bounce in Dock";
+"Post in Chat" = "Post in Chat";
+"Alert" = "Alert";
+"Notification" = "Notification";
+"Events settings table is available on macOS." = "Events settings table is available on macOS.";
+"Activity" = "Activity";
+"Filter errors" = "Filter errors";
+"No Errors" = "No Errors";
+"No logged errors for the current filter." = "No logged errors for the current filter.";
+"Clear" = "Clear";
+
+/* ── Menu / Commands ── */
+"No Bookmarks" = "No Bookmarks";
+"Window Tab for Bookmark" = "Window Tab for Bookmark";
+"New Tab for Bookmark" = "New Tab for Bookmark";
+"Reconnect" = "Reconnect";
+"Show Server Info" = "Show Server Info";
+"Set Topic" = "Set Topic";
+"New Broadcast" = "New Broadcast";
+"Change password..." = "Change password...";
+
+/* ── Quit / Close alerts ── */
+"Active connections and transfers" = "Active connections and transfers";
+"There are %lld active connections and active transfers. Quitting now will stop transfers." = "There are %lld active connections and active transfers. Quitting now will stop transfers.";
+"Disconnect and Quit" = "Disconnect and Quit";
+"Active connection" = "Active connection";
+"Active connections" = "Active connections";
+"Do you want to disconnect the active connection before quitting?" = "Do you want to disconnect the active connection before quitting?";
+"Do you want to disconnect %lld active connections before quitting?" = "Do you want to disconnect %lld active connections before quitting?";
+"Active transfers are in progress." = "Active transfers are in progress.";
+"Quitting now will stop active transfers." = "Quitting now will stop active transfers.";
+"Quit Anyway" = "Quit Anyway";
+"Do you want to disconnect the active connection before closing this window/tab?" = "Do you want to disconnect the active connection before closing this window/tab?";
+"Do you want to disconnect %lld active connections before closing this window/tab?" = "Do you want to disconnect %lld active connections before closing this window/tab?";
+
+/* ── Windows ── */
+"Error Log" = "Error Log";
+"Chat History" = "Chat History";
+
+/* ── Sidebar / MainView ── */
+"Delete Bookmark" = "Delete Bookmark";
+"Delete Tracker" = "Delete Tracker";
+"Show Transfers" = "Show Transfers";
+
+/* ── Change Password ── */
+"New password" = "New password";
+"Confirm password" = "Confirm password";
+"Change" = "Change";
+"Your account was migrated from Wired 2.5. You must set a new password before you can use this server." = "Your account was migrated from Wired 2.5. You must set a new password before you can use this server.";
+"No active connection." = "No active connection.";
+"Server error." = "Server error.";
+
+/* ── Boards ── */
+"Mark as Read" = "Mark as Read";
+"Mark as Unread" = "Mark as Unread";
+"Mark as read" = "Mark as read";
+"Mark as unread" = "Mark as unread";
+"Loading boards…" = "Loading boards…";
+"No Boards" = "No Boards";
+"No Smart Boards" = "No Smart Boards";
+"SMART BOARDS" = "SMART BOARDS";
+"BOARDS" = "BOARDS";
+"Delete Smart Board" = "Delete Smart Board";
+"Rename Board" = "Rename Board";
+"Edit Permissions" = "Edit Permissions";
+"Move Board" = "Move Board";
+"Delete Board" = "Delete Board";
+"New Board" = "New Board";
+"Boards network activity" = "Boards network activity";
+"Mark all as read" = "Mark all as read";
+"No Matching Threads" = "No Matching Threads";
+"Searching boards…" = "Searching boards…";
+"No Search Results" = "No Search Results";
+"Loading threads…" = "Loading threads…";
+"No Threads" = "No Threads";
+"Select a Board" = "Select a Board";
+"Select a Thread" = "Select a Thread";
+"New" = "New";
+"Reply" = "Reply";
+"Edit Thread" = "Edit Thread";
+"Move Thread" = "Move Thread";
+"Delete Thread" = "Delete Thread";
+"Reveal in Board" = "Reveal in Board";
+"Delete board?" = "Delete board?";
+"Delete smart board?" = "Delete smart board?";
+"Delete thread?" = "Delete thread?";
+"Threads" = "Threads";
+"Posts" = "Posts";
+"New Thread" = "New Thread";
+"Subject" = "Subject";
+"Post" = "Post";
+"Re: %@" = "Re: %@";
+
+/* ── Board Sheets ── */
+"Board Permissions" = "Board Permissions";
+"Board" = "Board";
+"Loading permissions…" = "Loading permissions…";
+"Loading accounts…" = "Loading accounts…";
+"Path" = "Path";
+"Current" = "Current";
+"Rename" = "Rename";
+"Move" = "Move";
+"Destination Path" = "Destination Path";
+"Destination" = "Destination";
+"Board Name" = "Board Name";
+"Location" = "Location";
+"Parent" = "Parent";
+
+/* ── Permission display names (wired.account.*) ── */
+"wired.account.color" = "Color";
+"wired.account.login" = "Login";
+"wired.account.nick" = "Nickname";
+"wired.account.create_accounts" = "Create Accounts";
+"wired.account.delete_accounts" = "Delete Accounts";
+"wired.account.read_accounts" = "Read Accounts";
+"wired.account.modify_accounts" = "Modify Accounts";
+"wired.account.alter_password" = "Alter Password";
+"wired.account.read_groups" = "Read Groups";
+"wired.account.create_groups" = "Create Groups";
+"wired.account.delete_groups" = "Delete Groups";
+"wired.account.modify_groups" = "Modify Groups";
+"wired.account.file.list_files" = "List Files";
+"wired.account.file.search" = "Search";
+"wired.account.file.get_info" = "Get Info";
+"wired.account.file.create_directories" = "Create Directories";
+"wired.account.file.create_links" = "Create Links";
+"wired.account.file.move_files" = "Move Files";
+"wired.account.file.rename_files" = "Rename Files";
+"wired.account.file.set_type" = "Set Type";
+"wired.account.file.set_comment" = "Set Comment";
+"wired.account.file.set_permissions" = "Set Permissions";
+"wired.account.file.set_label" = "Set Label";
+"wired.account.file.delete_files" = "Delete Files";
+"wired.account.file.access_all_dropboxes" = "Access All Dropboxes";
+"wired.account.file.set_aliases" = "Set Aliases";
+"wired.account.file.recursive_list_files" = "Recursive List Files";
+"wired.account.user.get_users" = "Get Users";
+"wired.account.user.get_info" = "Get User Info";
+"wired.account.user.disconnect_users" = "Disconnect Users";
+"wired.account.user.kick_users" = "Kick Users";
+"wired.account.user.ban_users" = "Ban Users";
+"wired.account.user.cannot_be_disconnected" = "Cannot Be Disconnected";
+"wired.account.user.list_offline_users" = "List Offline Users";
+"wired.account.transfer.download_files" = "Download Files";
+"wired.account.transfer.upload_files" = "Upload Files";
+"wired.account.transfer.upload_anywhere" = "Upload Anywhere";
+"wired.account.transfer.upload_directories" = "Upload Directories";
+"wired.account.transfer.download_limit" = "Download Limit";
+"wired.account.transfer.upload_limit" = "Upload Limit";
+"wired.account.message.send_messages" = "Send Messages";
+"wired.account.message.broadcast" = "Broadcast";
+"wired.account.board.read_boards" = "Read Boards";
+"wired.account.board.add_boards" = "Add Boards";
+"wired.account.board.move_boards" = "Move Boards";
+"wired.account.board.rename_boards" = "Rename Boards";
+"wired.account.board.delete_boards" = "Delete Boards";
+"wired.account.board.get_board_info" = "Get Board Info";
+"wired.account.board.set_board_info" = "Set Board Info";
+"wired.account.board.add_threads" = "Add Threads";
+"wired.account.board.move_threads" = "Move Threads";
+"wired.account.board.delete_all_threads_and_posts" = "Delete All Threads and Posts";
+"wired.account.board.delete_own_threads_and_posts" = "Delete Own Threads and Posts";
+"wired.account.board.edit_all_threads_and_posts" = "Edit All Threads and Posts";
+"wired.account.board.edit_own_threads_and_posts" = "Edit Own Threads and Posts";
+"wired.account.board.add_posts" = "Add Posts";
+"wired.account.board.delete_all_posts" = "Delete All Posts";
+"wired.account.board.edit_own_posts" = "Edit Own Posts";
+"wired.account.board.search_boards" = "Search Boards";
+"wired.account.administration.take_screenshots" = "Take Screenshots";
+"wired.account.administration.rename_server" = "Rename Server";
+"wired.account.administration.send_serverinfo" = "Send Server Info";
+"wired.account.administration.get_server_info" = "Get Server Info";
+"wired.account.administration.set_server_banner" = "Set Server Banner";
+"wired.account.tracker.list_servers" = "List Servers";
+"wired.account.tracker.register_servers" = "Register Servers";
+"wired.account.banlist.get_bans" = "Get Bans";
+"wired.account.banlist.add_bans" = "Add Bans";
+"wired.account.banlist.delete_bans" = "Delete Bans";
+
+/* ── File preview panel ── */
+"No Selection" = "No Selection";
+"Executable" = "Executable";
+"1 item" = "1 item";
+"%lld items" = "%lld items";
+"Sync Pair" = "Sync Pair";
+"Pair" = "Pair";
+"Active" = "Active";
+"Inactive" = "Inactive";
+"Mode" = "Mode";
+"Checking…" = "Checking…";
+"Paused" = "Paused";
+"Syncing…" = "Syncing…";
+"Reconnecting" = "Reconnecting";
+"Error" = "Error";
+
+/* ── Chat privileges ── */
+"wired.account.chat.kick_users" = "Kick Users";
+"wired.account.chat.set_topic" = "Set Topic";
+"wired.account.chat.create_chats" = "Create Chats";
+"wired.account.chat.create_public_chats" = "Create Public Chats";
+"wired.account.chat.delete_public_chats" = "Delete Public Chats";
+
+/* ── User privileges (additions) ── */
+"wired.account.user.cannot_set_nick" = "Cannot Set Nick";
+
+/* ── Message privileges (additions) ── */
+"wired.account.message.send_offline_messages" = "Send Offline Messages";
+
+/* ── Board privileges (additions) ── */
+"wired.account.board.add_reactions" = "Add Reactions";
+
+/* ── File privileges (additions) ── */
+"wired.account.file.search_files" = "Search Files";
+"wired.account.file.set_executable" = "Set Executable";
+"wired.account.file.recursive_list_depth_limit" = "Recursive List Depth Limit";
+"wired.account.file.sync.sync_files" = "Sync Files";
+"wired.account.file.sync.delete_remote" = "Delete Remote Files";
+
+/* ── Transfer privileges (additions) ── */
+"wired.account.transfer.download_speed_limit" = "Download Speed Limit";
+"wired.account.transfer.upload_speed_limit" = "Upload Speed Limit";
+
+/* ── Attachment privileges ── */
+"wired.account.attachment.upload" = "Upload Attachments";
+
+/* ── Account management privileges ── */
+"wired.account.account.change_password" = "Change Password";
+"wired.account.account.list_accounts" = "List Accounts";
+"wired.account.account.read_accounts" = "Read Accounts";
+"wired.account.account.create_users" = "Create Users";
+"wired.account.account.edit_users" = "Edit Users";
+"wired.account.account.delete_users" = "Delete Users";
+"wired.account.account.create_groups" = "Create Groups";
+"wired.account.account.edit_groups" = "Edit Groups";
+"wired.account.account.delete_groups" = "Delete Groups";
+"wired.account.account.raise_account_privileges" = "Raise Account Privileges";
+
+/* ── Log / Events / Settings privileges ── */
+"wired.account.log.view_log" = "View Log";
+"wired.account.events.view_events" = "View Events";
+"wired.account.settings.get_settings" = "Get Settings";
+"wired.account.settings.set_settings" = "Set Settings";
+
+/* ── Files toolbar ── */
+"Display Mode" = "Display Mode";
+"Navigate Backward" = "Navigate Backward";
+"Navigate Forward" = "Navigate Forward";
+"Reload Files" = "Reload Files";
+"Download File(s)" = "Download File(s)";
+"Upload File(s)" = "Upload File(s)";
+"Create Folder" = "Create Folder";
+"Delete File(s)" = "Delete File(s)";
+
+/* ── Files overwrite alert ── */
+"File Already Exists" = "File Already Exists";
+"A file already exists at:\n%@\n\nOverwrite it?" = "A file already exists at:\n%@\n\nOverwrite it?";
+"Overwrite" = "Overwrite";
+
+/* ── Files column headers ── */
+"Kind" = "Kind";
+
+/* ── Files context menu ── */
+"Quick Look" = "Quick Look";
+"New Folder" = "New Folder";
+"Upload…" = "Upload…";
+
+/* ── Sync context menu ── */
+"Activate Sync Pair" = "Activate Sync Pair";
+"Sync Now" = "Sync Now";
+"Sync Status: Pair inactive" = "Sync Status: Pair inactive";
+"Sync Status: Paused" = "Sync Status: Paused";
+"Sync Status: Connecting…" = "Sync Status: Connecting…";
+"Sync Status: Connected" = "Sync Status: Connected";
+"Sync Status: Syncing…" = "Sync Status: Syncing…";
+"Sync Status: Reconnecting…" = "Sync Status: Reconnecting…";
+"Sync Status: Updating…" = "Sync Status: Updating…";
+
+/* ── Sync tooltips ── */
+"Sync status pending" = "Sync status pending";
+"Sync paused" = "Sync paused";
+"Sync in progress" = "Sync in progress";
+"Sync reconnecting" = "Sync reconnecting";
+"Sync connected" = "Sync connected";
+"Sync error" = "Sync error";
+"Sync inactive" = "Sync inactive";

--- a/Wired 3/en.lproj/Localizable.strings
+++ b/Wired 3/en.lproj/Localizable.strings
@@ -652,7 +652,15 @@
 /* ── Files overwrite alert ── */
 "File Already Exists" = "File Already Exists";
 "A file already exists at:\n%@\n\nOverwrite it?" = "A file already exists at:\n%@\n\nOverwrite it?";
+"Do you want to overwrite \"%@\"?" = "Do you want to overwrite \"%@\"?";
 "Overwrite" = "Overwrite";
+
+/* ── Quick Look alert ── */
+"Download Preview?" = "Download Preview?";
+"Download Previews?" = "Download Previews?";
+"%@ is not cached yet and is larger than 512 KB.\nWired will fetch a lightweight Quick Look preview from the server." = "%@ is not cached yet and is larger than 512 KB.\nWired will fetch a lightweight Quick Look preview from the server.";
+"%lld selected files are not cached yet and are larger than 512 KB.\nWired will fetch lightweight Quick Look previews from the server." = "%lld selected files are not cached yet and are larger than 512 KB.\nWired will fetch lightweight Quick Look previews from the server.";
+"Quick Look Error" = "Quick Look Error";
 
 /* ── Files column headers ── */
 "Kind" = "Kind";

--- a/Wired 3/en.lproj/Localizable.strings
+++ b/Wired 3/en.lproj/Localizable.strings
@@ -299,6 +299,13 @@
 "Verified Identity" = "Verified Identity";
 "Identity not verified" = "Identity not verified";
 
+/* ── File types ── */
+"File" = "File";
+"Directory" = "Directory";
+"Uploads Folder" = "Uploads Folder";
+"Drop Box" = "Drop Box";
+"Sync Folder" = "Sync Folder";
+
 /* ── File Info sheet ── */
 "File Info" = "File Info";
 "Close" = "Close";

--- a/Wired 3/fr.lproj/Localizable.strings
+++ b/Wired 3/fr.lproj/Localizable.strings
@@ -297,6 +297,13 @@
 "Verified Identity" = "Identité vérifiée";
 "Identity not verified" = "Identité non vérifiée";
 
+/* ── File types ── */
+"File" = "Fichier";
+"Directory" = "Dossier";
+"Uploads Folder" = "Dossier de dépôt";
+"Drop Box" = "Boîte de dépôt";
+"Sync Folder" = "Dossier de synchronisation";
+
 /* ── File Info sheet ── */
 "File Info" = "Infos fichier";
 "Close" = "Fermer";

--- a/Wired 3/fr.lproj/Localizable.strings
+++ b/Wired 3/fr.lproj/Localizable.strings
@@ -650,7 +650,15 @@
 /* ── Files overwrite alert ── */
 "File Already Exists" = "Fichier déjà existant";
 "A file already exists at:\n%@\n\nOverwrite it?" = "Un fichier existe déjà à :\n%@\n\nL'écraser ?";
+"Do you want to overwrite \"%@\"?" = "Voulez-vous écraser « %@ » ?";
 "Overwrite" = "Écraser";
+
+/* ── Quick Look alert ── */
+"Download Preview?" = "Télécharger l'aperçu ?";
+"Download Previews?" = "Télécharger les aperçus ?";
+"%@ is not cached yet and is larger than 512 KB.\nWired will fetch a lightweight Quick Look preview from the server." = "%@ n'est pas encore en cache et dépasse 512 Ko.\nWired récupérera un aperçu Quick Look allégé depuis le serveur.";
+"%lld selected files are not cached yet and are larger than 512 KB.\nWired will fetch lightweight Quick Look previews from the server." = "%lld fichiers sélectionnés ne sont pas encore en cache et dépassent 512 Ko.\nWired récupérera des aperçus Quick Look allégés depuis le serveur.";
+"Quick Look Error" = "Erreur Quick Look";
 
 /* ── Files column headers ── */
 "Kind" = "Type";

--- a/Wired 3/fr.lproj/Localizable.strings
+++ b/Wired 3/fr.lproj/Localizable.strings
@@ -32,6 +32,17 @@
 "Never" = "Jamais";
 "Date" = "Date";
 "Category" = "Catégorie";
+"No" = "Non";
+"Edit" = "Éditer";
+"Remove" = "Retirer";
+"Start" = "Démarrer";
+"Pause" = "Pause";
+"Stop" = "Arrêter";
+"Size" = "Taille";
+"Description" = "Description";
+"URL" = "URL";
+"Status" = "Statut";
+"Info" = "Infos";
 
 /* ── Monitor view ── */
 "Access Denied" = "Accès refusé";
@@ -60,6 +71,34 @@
 "DL Speed" = "Vit. téléchargement";
 "Concurrent Uploads" = "Téléversements simultanés";
 "UL Speed" = "Vit. téléversement";
+
+/* ── Navigation ── */
+"Favorites" = "Favoris";
+"Connections" = "Connexions";
+"Trackers" = "Annuaires";
+"Add Tracker" = "Ajouter un annuaire";
+"New Connection" = "Nouvelle connexion";
+"Select an item" = "Sélectionner un élément";
+"Chats" = "Discussions";
+"Messages" = "Messages";
+"Boards" = "Forums";
+"Files" = "Fichiers";
+"Bookmark" = "Marque-page";
+"Connect" = "Connecter";
+"Tracker" = "Annuaire";
+"Loading tracker…" = "Chargement de l'annuaire…";
+"No servers listed" = "Aucun serveur répertorié";
+"Get Info" = "Afficher les infos";
+"Add to Favorites" = "Ajouter aux favoris";
+"Add to Trackers" = "Ajouter aux annuaires";
+"Connection" = "Connexion";
+
+/* ── Connection state ── */
+"Connecting…" = "Connexion en cours…";
+"Disconnected" = "Déconnecté";
+"Connection unavailable" = "Connexion indisponible";
+"Are you sure you want to disconnect from this server?" = "Voulez-vous vraiment vous déconnecter de ce serveur ?";
+"Disconnect and Close" = "Déconnecter et fermer";
 
 /* ── Tracker / Directory ── */
 "Each directory is registered as a `wired://host[:port]/Category` URL. The interface edits the parts and serializes them automatically." = "Chaque annuaire est enregistré sous forme d'URL `wired://hote[:port]/Categorie`. L'interface édite les différentes parties, puis les sérialise automatiquement.";
@@ -117,6 +156,48 @@
 "Comma-separated" = "Séparés par des virgules";
 "Example: staff, moderators" = "Exemple : staff, moderators";
 
+/* ── Chat / User list ── */
+"Online" = "En ligne";
+"Offline" = "Hors ligne";
+"Get Infos" = "Afficher les infos";
+"Send Private Message" = "Envoyer un message privé";
+"Invite to Private Chat" = "Inviter dans une discussion privée";
+"Kick" = "Éjecter";
+"Ban" = "Bannir";
+"Kick User" = "Éjecter l'utilisateur";
+"Ban User" = "Bannir l'utilisateur";
+"Chat here…" = "Discutez ici…";
+"Add a message or press Return to send…" = "Ajouter un message ou appuyer sur Retour pour envoyer…";
+
+/* ── User info panel ── */
+"App version" = "Version de l'app";
+"P7 Protocol" = "Protocole P7";
+"Wired Protocol" = "Protocole Wired";
+"OS Name" = "Système d'exploitation";
+"OS Version" = "Version du SE";
+"Arch" = "Architecture";
+"IP Address" = "Adresse IP";
+"Hostname" = "Nom d'hôte";
+"Cipher" = "Chiffrement";
+"Login Time" = "Heure de connexion";
+"Idle Time" = "Temps d'inactivité";
+"Transfer" = "Transfert";
+
+/* ── Messages ── */
+"Private Messages" = "Messages privés";
+"Broadcasts" = "Diffusions";
+"No Results" = "Aucun résultat";
+"Select a Conversation" = "Sélectionner une conversation";
+"No Conversation" = "Aucune conversation";
+"Open a conversation from the users list." = "Ouvrez une conversation depuis la liste des utilisateurs.";
+"Choose a conversation from the filtered results." = "Choisissez une conversation parmi les résultats filtrés.";
+"Try another search." = "Essayez une autre recherche.";
+"No broadcast permission" = "Aucune permission de diffusion";
+"User unavailable" = "Utilisateur indisponible";
+"Broadcast message required…" = "Message de diffusion requis…";
+"Broadcast to all online users…" = "Diffuser à tous les utilisateurs en ligne…";
+"Type message here…" = "Saisissez votre message ici…";
+
 /* ── Smart Board Editor ── */
 "New Smart Board" = "Nouvelle discussion intelligente";
 "Edit Smart Board" = "Modifier la discussion intelligente";
@@ -141,6 +222,16 @@
 "Preview" = "Aperçu";
 "Nothing to preview" = "Rien à prévisualiser";
 
+/* ── Transfers ── */
+"Remove transfer?" = "Supprimer le transfert ?";
+"Remove Transfers" = "Supprimer les transferts";
+"Remove Transfer" = "Supprimer le transfert";
+"Are you sure you want to remove this transfer?" = "Voulez-vous vraiment supprimer ce transfert ?";
+"Clear finished transfers" = "Effacer les transferts terminés";
+"Show in Finder" = "Afficher dans le Finder";
+"Show Remote Location" = "Afficher l'emplacement distant";
+"Unknown Server" = "Serveur inconnu";
+
 /* ── Files ── */
 "Unable to download \"%@\":\n%@" = "Impossible de télécharger \"%@\" :\n%@";
 
@@ -158,3 +249,433 @@
 "Owner" = "Propriétaire";
 "Owner access" = "Accès propriétaire";
 "Group access" = "Accès groupe";
+
+/* ── Server Settings – General/Log tabs ── */
+"General" = "Général";
+"Log" = "Journal";
+"KB/s" = "Ko/s";
+"bytes" = "octets";
+"Unlimited" = "Illimité";
+"0 = unlimited" = "0 = illimité";
+"Effective Mode" = "Mode effectif";
+"Auto-reconnecting..." = "Reconnexion automatique...";
+
+/* ── Accounts – detail fields ── */
+"Identity" = "Identité";
+"Created" = "Créé";
+"Modified" = "Modifié";
+"Last Login" = "Dernière connexion";
+"Modified By" = "Modifié par";
+"Downloads" = "Téléchargements";
+"Uploads" = "Téléversements";
+"Add User" = "Ajouter un utilisateur";
+"Add Group" = "Ajouter un groupe";
+"Initial password" = "Mot de passe initial";
+
+/* ── Accounts – permission categories ── */
+"Basic" = "Basique";
+"Administration" = "Administration";
+"Limits" = "Limites";
+"Other" = "Autre";
+"Color" = "Couleur";
+"Black" = "Noir";
+"Red" = "Rouge";
+"Orange" = "Orange";
+"Green" = "Vert";
+"Blue" = "Bleu";
+"Purple" = "Violet";
+
+/* ── Server Info tab ── */
+"Application" = "Application";
+"Version" = "Version";
+"System" = "Système";
+"OS" = "SE";
+"Architecture" = "Architecture";
+"Count" = "Nombre";
+"Uptime" = "Disponibilité";
+"Loading server information…" = "Chargement des informations du serveur…";
+"Verified Identity" = "Identité vérifiée";
+"Identity not verified" = "Identité non vérifiée";
+
+/* ── File Info sheet ── */
+"File Info" = "Infos fichier";
+"Close" = "Fermer";
+"Metadata" = "Métadonnées";
+"Label" = "Étiquette";
+"Data" = "Données";
+"Resource" = "Ressource";
+"Total" = "Total";
+"Folder" = "Dossier";
+"Contains" = "Contient";
+"Folder Permissions" = "Permissions du dossier";
+"Access" = "Accès";
+"Everyone" = "Tout le monde";
+"Sync Policy" = "Politique de sync";
+"Max File Size" = "Taille max de fichier";
+"Max Tree Size" = "Taille max du répertoire";
+"Exclude Patterns" = "Motifs d'exclusion";
+"Quota" = "Quota";
+"No Access" = "Aucun accès";
+"Read & Write" = "Lecture et écriture";
+"Read Only" = "Lecture seule";
+"Write Only" = "Écriture seule";
+"Disabled" = "Désactivé";
+"Server → Client" = "Serveur → Client";
+"Client → Server" = "Client → Serveur";
+"Bidirectional" = "Bidirectionnel";
+
+/* ── Réglages de l'app ── */
+"Icon" = "Icône";
+"Choose..." = "Choisir…";
+"Nickname" = "Pseudo";
+"Find" = "Rechercher";
+"About Wired 3" = "À propos de Wired 3";
+"Settings..." = "Réglages…";
+
+/* ── Catégorie de permission ── */
+"Transfers" = "Transferts";
+
+/* ── Transferts – infobulles ── */
+"Play transfer" = "Démarrer le transfert";
+"Pause transfer" = "Mettre le transfert en pause";
+"Stop transfer" = "Arrêter le transfert";
+"Remove transfer" = "Supprimer le transfert";
+
+/* ── Fichiers ── */
+"Create Directory" = "Créer un dossier";
+"Delete File" = "Supprimer le fichier";
+"Delete Files" = "Supprimer les fichiers";
+"Are you sure you want to delete this file? This operation is not recoverable." = "Voulez-vous vraiment supprimer ce fichier ? Cette opération est irréversible.";
+"Are you sure you want to delete this selection? This operation is not recoverable." = "Voulez-vous vraiment supprimer cette sélection ? Cette opération est irréversible.";
+"Upload Blocked" = "Téléversement bloqué";
+"Searching…" = "Recherche en cours…";
+
+/* ── Sync ── */
+"Deactivate Sync Pair" = "Désactiver la paire de sync";
+"Sync Error" = "Erreur de sync";
+"Sync Enabled" = "Sync activée";
+"Sync Triggered" = "Sync déclenchée";
+"Sync Already Running" = "Sync déjà en cours";
+"Sync Disabled" = "Sync désactivée";
+"Your account is not allowed to activate sync pairs." = "Votre compte n'est pas autorisé à activer des paires de sync.";
+"No active Wired connection available for sync activation." = "Aucune connexion Wired active pour l'activation de la sync.";
+"The selected sync folder is disabled for your account." = "Le dossier de sync sélectionné est désactivé pour votre compte.";
+"No active Wired connection available for sync deactivation." = "Aucune connexion Wired active pour la désactivation de la sync.";
+
+/* ── Onglets Réglages ── */
+"Chat" = "Discussion";
+"Behavior" = "Comportement";
+"Check for active connections before closing" = "Vérifier les connexions actives avant de fermer";
+"Timestamp in Chats and Messages" = "Horodatage dans les discussions et messages";
+"Every (min.)" = "Toutes les (min.)";
+"Messages displayed" = "Messages affichés";
+"Timestamp every message" = "Horodater chaque message";
+"Emoji" = "Emoji";
+"Substitute Emoji" = "Remplacer les Emoji";
+"Emoji Substitutions" = "Substitutions Emoji";
+"History" = "Historique";
+"Archive Chat Messages" = "Archiver les messages de discussion";
+"When enabled, chat messages are saved locally for later browsing in Chat History." = "Lorsque cette option est activée, les messages sont enregistrés localement pour être consultés dans l'historique.";
+"Highlights" = "Mises en évidence";
+"No highlights yet." = "Aucune mise en évidence.";
+"Keyword" = "Mot-clé";
+"Delete Highlight?" = "Supprimer la mise en évidence ?";
+"This highlight has no keyword. Do you want to delete it?" = "Cette mise en évidence n'a pas de mot-clé. Voulez-vous la supprimer ?";
+"Do you want to delete the highlight for \"%@\"?" = "Voulez-vous supprimer la mise en évidence pour \"%@\" ?";
+"Do you want to delete this highlight?" = "Voulez-vous supprimer cette mise en évidence ?";
+"No emoji substitutions yet." = "Aucune substitution Emoji.";
+"Code" = "Code";
+"Delete Emoji Substitution?" = "Supprimer la substitution Emoji ?";
+"Do you want to delete this emoji substitution?" = "Voulez-vous supprimer cette substitution Emoji ?";
+"Add Highlight" = "Ajouter une mise en évidence";
+"Add Substitution" = "Ajouter une substitution";
+"Back" = "Retour";
+"Download Folder" = "Dossier de téléchargement";
+"Volume" = "Volume";
+"Event Configuration" = "Configuration des événements";
+"Sound" = "Son";
+"Bounce in Dock" = "Rebondir dans le Dock";
+"Post in Chat" = "Publier dans la discussion";
+"Alert" = "Alerte";
+"Notification" = "Notification";
+"Events settings table is available on macOS." = "Le tableau de configuration des événements est disponible sur macOS.";
+"Activity" = "Activité";
+"Filter errors" = "Filtrer les erreurs";
+"No Errors" = "Aucune erreur";
+"No logged errors for the current filter." = "Aucune erreur enregistrée pour le filtre courant.";
+"Clear" = "Effacer";
+
+/* ── Commandes de menu ── */
+"No Bookmarks" = "Aucun marque-page";
+"Window Tab for Bookmark" = "Onglet fenêtre pour le marque-page";
+"New Tab for Bookmark" = "Nouvel onglet pour le marque-page";
+"Reconnect" = "Se reconnecter";
+"Show Server Info" = "Afficher les infos du serveur";
+"Set Topic" = "Définir le sujet";
+"New Broadcast" = "Nouvelle diffusion";
+"Change password..." = "Modifier le mot de passe...";
+
+/* ── Alertes Quitter/Fermer ── */
+"Active connections and transfers" = "Connexions et transferts actifs";
+"There are %lld active connections and active transfers. Quitting now will stop transfers." = "Il y a %lld connexions actives et des transferts en cours. Quitter maintenant arrêtera les transferts.";
+"Disconnect and Quit" = "Déconnecter et quitter";
+"Active connection" = "Connexion active";
+"Active connections" = "Connexions actives";
+"Do you want to disconnect the active connection before quitting?" = "Voulez-vous déconnecter la connexion active avant de quitter ?";
+"Do you want to disconnect %lld active connections before quitting?" = "Voulez-vous déconnecter %lld connexions actives avant de quitter ?";
+"Active transfers are in progress." = "Des transferts actifs sont en cours.";
+"Quitting now will stop active transfers." = "Quitter maintenant arrêtera les transferts actifs.";
+"Quit Anyway" = "Quitter quand même";
+"Do you want to disconnect the active connection before closing this window/tab?" = "Voulez-vous déconnecter la connexion active avant de fermer cette fenêtre/cet onglet ?";
+"Do you want to disconnect %lld active connections before closing this window/tab?" = "Voulez-vous déconnecter %lld connexions actives avant de fermer cette fenêtre/cet onglet ?";
+
+/* ── Fenêtres ── */
+"Error Log" = "Journal d'erreurs";
+"Chat History" = "Historique des discussions";
+
+/* ── Barre latérale / Vue principale ── */
+"Delete Bookmark" = "Supprimer le marque-page";
+"Delete Tracker" = "Supprimer l'annuaire";
+"Show Transfers" = "Afficher les transferts";
+
+/* ── Changement de mot de passe ── */
+"New password" = "Nouveau mot de passe";
+"Confirm password" = "Confirmer le mot de passe";
+"Change" = "Modifier";
+"Your account was migrated from Wired 2.5. You must set a new password before you can use this server." = "Votre compte a été migré depuis Wired 2.5. Vous devez définir un nouveau mot de passe avant de pouvoir utiliser ce serveur.";
+"No active connection." = "Pas de connexion active.";
+"Server error." = "Erreur serveur.";
+
+/* ── Forums ── */
+"Mark as Read" = "Marquer comme lu";
+"Mark as Unread" = "Marquer comme non lu";
+"Mark as read" = "Marquer comme lu";
+"Mark as unread" = "Marquer comme non lu";
+"Loading boards…" = "Chargement des forums…";
+"No Boards" = "Aucun forum";
+"No Smart Boards" = "Aucun Smart Board";
+"SMART BOARDS" = "SMART BOARDS";
+"BOARDS" = "FORUMS";
+"Delete Smart Board" = "Supprimer le Smart Board";
+"Rename Board" = "Renommer le forum";
+"Edit Permissions" = "Modifier les permissions";
+"Move Board" = "Déplacer le forum";
+"Delete Board" = "Supprimer le forum";
+"New Board" = "Nouveau forum";
+"Boards network activity" = "Activité réseau des forums";
+"Mark all as read" = "Tout marquer comme lu";
+"No Matching Threads" = "Aucun fil correspondant";
+"Searching boards…" = "Recherche dans les forums…";
+"No Search Results" = "Aucun résultat";
+"Loading threads…" = "Chargement des fils…";
+"No Threads" = "Aucun fil";
+"Select a Board" = "Sélectionner un forum";
+"Select a Thread" = "Sélectionner un fil";
+"New" = "Nouveau";
+"Reply" = "Répondre";
+"Edit Thread" = "Modifier le fil";
+"Move Thread" = "Déplacer le fil";
+"Delete Thread" = "Supprimer le fil";
+"Reveal in Board" = "Afficher dans le forum";
+"Delete board?" = "Supprimer le forum ?";
+"Delete smart board?" = "Supprimer le Smart Board ?";
+"Delete thread?" = "Supprimer le fil ?";
+"Threads" = "Fils";
+"Posts" = "Messages";
+"New Thread" = "Nouveau fil";
+"Subject" = "Sujet";
+"Post" = "Publier";
+"Re: %@" = "Re : %@";
+
+/* ── Feuilles de forum ── */
+"Board Permissions" = "Permissions du forum";
+"Board" = "Forum";
+"Loading permissions…" = "Chargement des permissions…";
+"Loading accounts…" = "Chargement des comptes…";
+"Path" = "Chemin";
+"Current" = "Actuel";
+"Rename" = "Renommer";
+"Move" = "Déplacer";
+"Destination Path" = "Chemin de destination";
+"Destination" = "Destination";
+"Board Name" = "Nom du forum";
+"Location" = "Emplacement";
+"Parent" = "Parent";
+
+/* ── Noms des permissions (wired.account.*) ── */
+"wired.account.color" = "Couleur";
+"wired.account.login" = "Connexion";
+"wired.account.nick" = "Surnom";
+"wired.account.create_accounts" = "Créer des comptes";
+"wired.account.delete_accounts" = "Supprimer des comptes";
+"wired.account.read_accounts" = "Lire les comptes";
+"wired.account.modify_accounts" = "Modifier les comptes";
+"wired.account.alter_password" = "Modifier le mot de passe";
+"wired.account.read_groups" = "Lire les groupes";
+"wired.account.create_groups" = "Créer des groupes";
+"wired.account.delete_groups" = "Supprimer des groupes";
+"wired.account.modify_groups" = "Modifier les groupes";
+"wired.account.file.list_files" = "Lister les fichiers";
+"wired.account.file.search" = "Rechercher";
+"wired.account.file.get_info" = "Obtenir les infos";
+"wired.account.file.create_directories" = "Créer des dossiers";
+"wired.account.file.create_links" = "Créer des liens";
+"wired.account.file.move_files" = "Déplacer des fichiers";
+"wired.account.file.rename_files" = "Renommer des fichiers";
+"wired.account.file.set_type" = "Définir le type";
+"wired.account.file.set_comment" = "Définir le commentaire";
+"wired.account.file.set_permissions" = "Définir les permissions";
+"wired.account.file.set_label" = "Définir le label";
+"wired.account.file.delete_files" = "Supprimer des fichiers";
+"wired.account.file.access_all_dropboxes" = "Accéder à toutes les dropbox";
+"wired.account.file.set_aliases" = "Définir les alias";
+"wired.account.file.recursive_list_files" = "Lister les fichiers récursivement";
+"wired.account.user.get_users" = "Obtenir les utilisateurs";
+"wired.account.user.get_info" = "Obtenir les infos utilisateur";
+"wired.account.user.disconnect_users" = "Déconnecter les utilisateurs";
+"wired.account.user.kick_users" = "Expulser les utilisateurs";
+"wired.account.user.ban_users" = "Bannir les utilisateurs";
+"wired.account.user.cannot_be_disconnected" = "Ne peut pas être déconnecté";
+"wired.account.user.list_offline_users" = "Lister les utilisateurs hors ligne";
+"wired.account.transfer.download_files" = "Télécharger des fichiers";
+"wired.account.transfer.upload_files" = "Envoyer des fichiers";
+"wired.account.transfer.upload_anywhere" = "Envoyer n'importe où";
+"wired.account.transfer.upload_directories" = "Envoyer des dossiers";
+"wired.account.transfer.download_limit" = "Limite de téléchargement";
+"wired.account.transfer.upload_limit" = "Limite d'envoi";
+"wired.account.message.send_messages" = "Envoyer des messages";
+"wired.account.message.broadcast" = "Diffuser";
+"wired.account.board.read_boards" = "Lire les forums";
+"wired.account.board.add_boards" = "Ajouter des forums";
+"wired.account.board.move_boards" = "Déplacer des forums";
+"wired.account.board.rename_boards" = "Renommer des forums";
+"wired.account.board.delete_boards" = "Supprimer des forums";
+"wired.account.board.get_board_info" = "Obtenir les infos du forum";
+"wired.account.board.set_board_info" = "Définir les infos du forum";
+"wired.account.board.add_threads" = "Ajouter des fils";
+"wired.account.board.move_threads" = "Déplacer des fils";
+"wired.account.board.delete_all_threads_and_posts" = "Supprimer tous les fils et messages";
+"wired.account.board.delete_own_threads_and_posts" = "Supprimer ses fils et messages";
+"wired.account.board.edit_all_threads_and_posts" = "Modifier tous les fils et messages";
+"wired.account.board.edit_own_threads_and_posts" = "Modifier ses fils et messages";
+"wired.account.board.add_posts" = "Ajouter des messages";
+"wired.account.board.delete_all_posts" = "Supprimer tous les messages";
+"wired.account.board.edit_own_posts" = "Modifier ses propres messages";
+"wired.account.board.search_boards" = "Rechercher dans les forums";
+"wired.account.administration.take_screenshots" = "Prendre des captures d'écran";
+"wired.account.administration.rename_server" = "Renommer le serveur";
+"wired.account.administration.send_serverinfo" = "Envoyer les infos serveur";
+"wired.account.administration.get_server_info" = "Obtenir les infos serveur";
+"wired.account.administration.set_server_banner" = "Définir la bannière serveur";
+"wired.account.tracker.list_servers" = "Lister les serveurs";
+"wired.account.tracker.register_servers" = "Enregistrer des serveurs";
+"wired.account.banlist.get_bans" = "Obtenir les bannissements";
+"wired.account.banlist.add_bans" = "Ajouter des bannissements";
+"wired.account.banlist.delete_bans" = "Supprimer des bannissements";
+
+/* ── File preview panel ── */
+"No Selection" = "Aucune sélection";
+"Executable" = "Exécutable";
+"1 item" = "1 élément";
+"%lld items" = "%lld éléments";
+"Sync Pair" = "Paire de sync";
+"Pair" = "Paire";
+"Active" = "Actif";
+"Inactive" = "Inactif";
+"Mode" = "Mode";
+"Checking…" = "Vérification…";
+"Paused" = "En pause";
+"Syncing…" = "Synchronisation…";
+"Reconnecting" = "Reconnexion";
+"Error" = "Erreur";
+
+/* ── Chat privileges ── */
+"wired.account.chat.kick_users" = "Expulser des utilisateurs";
+"wired.account.chat.set_topic" = "Définir le sujet";
+"wired.account.chat.create_chats" = "Créer des chats";
+"wired.account.chat.create_public_chats" = "Créer des chats publics";
+"wired.account.chat.delete_public_chats" = "Supprimer des chats publics";
+
+/* ── User privileges (additions) ── */
+"wired.account.user.cannot_set_nick" = "Ne peut pas changer de pseudo";
+
+/* ── Message privileges (additions) ── */
+"wired.account.message.send_offline_messages" = "Envoyer des messages hors ligne";
+
+/* ── Board privileges (additions) ── */
+"wired.account.board.add_reactions" = "Ajouter des réactions";
+
+/* ── File privileges (additions) ── */
+"wired.account.file.search_files" = "Rechercher des fichiers";
+"wired.account.file.set_executable" = "Rendre exécutable";
+"wired.account.file.recursive_list_depth_limit" = "Limite de profondeur récursive";
+"wired.account.file.sync.sync_files" = "Synchroniser les fichiers";
+"wired.account.file.sync.delete_remote" = "Supprimer les fichiers distants";
+
+/* ── Transfer privileges (additions) ── */
+"wired.account.transfer.download_speed_limit" = "Limite de vitesse de téléchargement";
+"wired.account.transfer.upload_speed_limit" = "Limite de vitesse d'envoi";
+
+/* ── Attachment privileges ── */
+"wired.account.attachment.upload" = "Envoyer des pièces jointes";
+
+/* ── Account management privileges ── */
+"wired.account.account.change_password" = "Changer le mot de passe";
+"wired.account.account.list_accounts" = "Lister les comptes";
+"wired.account.account.read_accounts" = "Lire les comptes";
+"wired.account.account.create_users" = "Créer des utilisateurs";
+"wired.account.account.edit_users" = "Modifier des utilisateurs";
+"wired.account.account.delete_users" = "Supprimer des utilisateurs";
+"wired.account.account.create_groups" = "Créer des groupes";
+"wired.account.account.edit_groups" = "Modifier des groupes";
+"wired.account.account.delete_groups" = "Supprimer des groupes";
+"wired.account.account.raise_account_privileges" = "Élever les privilèges";
+
+/* ── Log / Events / Settings privileges ── */
+"wired.account.log.view_log" = "Voir le journal";
+"wired.account.events.view_events" = "Voir les événements";
+"wired.account.settings.get_settings" = "Lire les paramètres";
+"wired.account.settings.set_settings" = "Modifier les paramètres";
+
+/* ── Files toolbar ── */
+"Display Mode" = "Mode d'affichage";
+"Navigate Backward" = "Naviguer en arrière";
+"Navigate Forward" = "Naviguer en avant";
+"Reload Files" = "Recharger les fichiers";
+"Download File(s)" = "Télécharger le(s) fichier(s)";
+"Upload File(s)" = "Envoyer le(s) fichier(s)";
+"Create Folder" = "Créer un dossier";
+"Delete File(s)" = "Supprimer le(s) fichier(s)";
+
+/* ── Files overwrite alert ── */
+"File Already Exists" = "Fichier déjà existant";
+"A file already exists at:\n%@\n\nOverwrite it?" = "Un fichier existe déjà à :\n%@\n\nL'écraser ?";
+"Overwrite" = "Écraser";
+
+/* ── Files column headers ── */
+"Kind" = "Type";
+
+/* ── Files context menu ── */
+"Quick Look" = "Aperçu rapide";
+"New Folder" = "Nouveau dossier";
+"Upload…" = "Envoyer…";
+
+/* ── Sync context menu ── */
+"Activate Sync Pair" = "Activer la paire de sync";
+"Sync Now" = "Synchroniser maintenant";
+"Sync Status: Pair inactive" = "État sync : paire inactive";
+"Sync Status: Paused" = "État sync : en pause";
+"Sync Status: Connecting…" = "État sync : connexion…";
+"Sync Status: Connected" = "État sync : connecté";
+"Sync Status: Syncing…" = "État sync : synchronisation…";
+"Sync Status: Reconnecting…" = "État sync : reconnexion…";
+"Sync Status: Updating…" = "État sync : mise à jour…";
+
+/* ── Sync tooltips ── */
+"Sync status pending" = "État sync en attente";
+"Sync paused" = "Sync en pause";
+"Sync in progress" = "Sync en cours";
+"Sync reconnecting" = "Sync reconnexion";
+"Sync connected" = "Sync connecté";
+"Sync error" = "Erreur de sync";
+"Sync inactive" = "Sync inactif";

--- a/Wired-macOS.xcodeproj/project.pbxproj
+++ b/Wired-macOS.xcodeproj/project.pbxproj
@@ -288,6 +288,7 @@
 		CC100004FA00000100213277 /* ChatHistoryDayList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatHistoryDayList.swift; sourceTree = "<group>"; };
 		CC100005FA00000100213277 /* ChatHistoryMessagesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatHistoryMessagesView.swift; sourceTree = "<group>"; };
 		CC100006FA00000100213277 /* ArchiveMessageBubbleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveMessageBubbleView.swift; sourceTree = "<group>"; };
+		F69436752FA4A557005137D5 /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/Localizable.strings; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
@@ -750,8 +751,8 @@
 			knownRegions = (
 				en,
 				Base,
-				de,
 				fr,
+				de,
 			);
 			mainGroup = 4C74285522DCECE800D6E6F9;
 			packageReferences = (
@@ -992,6 +993,7 @@
 			children = (
 				84F9192333CB2A6EFE6941E0 /* en */,
 				5D426E2D2F723AA85053E8C8 /* fr */,
+				F69436752FA4A557005137D5 /* de */,
 			);
 			name = Localizable.strings;
 			sourceTree = "<group>";


### PR DESCRIPTION
## Summary

- **Add `de.lproj/Localizable.strings`** — full German translation of all UI strings
- **Complete `en/fr` strings coverage** — Files area, Accounts permissions, and AppKit UI strings that were previously untranslated
- **Fix NSLocalizedString wrapping** — AppKit UI elements (NSAlert, NSTableColumn, NSMenu, toolTip) now use `NSLocalizedString()` so they respond to system language; SwiftUI `Text()` calls receiving `String` variables now use `Text(LocalizedStringKey(…))`
- **Fix typo** — "Navigate Backwark" → "Navigate Backward"

## Strings added/fixed

### Files area
- Column headers: Name, Kind, Modified, Size
- Toolbar: Navigate Backward/Forward, Reload Files, Download/Upload, Create Folder, Delete
- Context menu: Quick Look, Get Info, Download, New Folder, Upload…, Delete, 8 Sync Status entries
- Sync tooltips (7 entries)
- File preview panel: Type, Size, Created, Modified, Contains (with plural: "1 item" / "%lld items"), Executable, Sync Pair section labels
- Overwrite alert: "File Already Exists", format string, "Overwrite", "Stop"

### Server Settings → Accounts
- All wired.account.* privilege strings matching the P7 protocol spec

### Disconnect on close alert
- "Active connection" / "Do you want to disconnect the active connection before closing this window/tab?"

## Test plan
- [ ] Launch app with System Language set to German — all UI labels appear in German
- [ ] Launch app with System Language set to French — all UI labels appear in French
- [ ] Launch app with System Language set to English — English fallback
- [ ] Files view: column headers, context menu items, and sidebar preview panel (Type/Size/Created/Modified/Contains) all localized
- [ ] Server Settings → Accounts → select a user → Permissions section labels all localized
- [ ] Closing a window with an active connection shows the alert in the correct language

🤖 Generated with [Claude Code](https://claude.com/claude-code)