### PR TITLE
fix(server-info): use actual connection port for TOFU fingerprint lookup

### DIFF
--- a/Wired 3/Views/ServerInfo/ServerInfoView.swift
+++ b/Wired 3/Views/ServerInfo/ServerInfoView.swift
@@ -13,10 +13,10 @@ struct ServerInfoView: View {
 
     /// Stored TOFU fingerprint for this server, if any.
     private var serverTrustFingerprint: String? {
-        guard let hostname = runtime.connectionController.configuration(for: runtime.id)?.hostname else {
+        guard let config = runtime.connectionController.configuration(for: runtime.id) else {
             return nil
         }
-        return ServerTrustStore.storedFingerprint(host: hostname, port: 4871)
+        return ServerTrustStore.storedFingerprint(host: config.hostname, port: config.url.port)
     }
 
     var body: some View {


### PR DESCRIPTION
## Summary
Cherry-pick of the targeted `ServerInfoView` fix from #32, isolated onto `master` so it can be merged without the unrelated changes that PR carried.

`ServerInfoView` was hardcoding port `4871` when looking up the stored TOFU fingerprint, causing a mismatch for servers running on non-default ports. It now uses `config.url.port` so the lookup matches the key used when the fingerprint was stored during the P7 handshake.

Credit to @martinmarsian for the original fix in #32.

## Test plan
- [ ] Connect to a server on a non-default port and verify the TOFU fingerprint is displayed in Server Info
- [ ] Connect to a server on the default port 4871 and verify the fingerprint still resolves