### PR TITLE
feat(connection): surface client/server protocol version drift

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -172,4 +172,9 @@ At a high level:
 - `wiredsyncd` handles folder synchronization in the background
 - `WiredSwift` provides the underlying protocol and connection layer
 
+If your change touches the Wired protocol itself (new fields, new messages,
+new behaviour gated on the peer's version), follow the rules documented in
+[`WiredSwift/COMPATIBILITY.md`](../WiredSwift/COMPATIBILITY.md) — the same
+policy applies on both sides of the wire.
+
 If you are changing behavior in the client UI, please keep the public product name as **Wired Client** in user-facing text unless there is a strong reason not to.

--- a/README.md
+++ b/README.md
@@ -159,6 +159,8 @@ The [WiredSwift](https://github.com/nark/WiredSwift) repository includes:
 - **wired3**: the server daemon
 - **WiredServerApp**: the macOS GUI app for local server administration
 
+Wired Client interoperates with any Wired 3 server sharing the same protocol *major* version. Minor-version differences are negotiated transparently — see [`WiredSwift/COMPATIBILITY.md`](https://github.com/nark/WiredSwift/blob/master/COMPATIBILITY.md) for the policy.
+
 In practice, a Wired server can host a private community with:
 
 - multiple public chats

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -37,7 +37,7 @@ If you would like to remain uncredited in release notes or advisories, say so in
 
 Important security-sensitive areas in this repository include:
 
-- **Connection and authentication flows** in the macOS client
+- **Connection and authentication flows** in the macOS client (including the cross-version protocol diff exchange — see [`WiredSwift/COMPATIBILITY.md`](../WiredSwift/COMPATIBILITY.md))
 - **Server identity trust** and TOFU fingerprint handling
 - **Credential storage** in the macOS Keychain
 - **File transfers** and local file handling

--- a/Wired 3/Additions/View.swift
+++ b/Wired 3/Additions/View.swift
@@ -128,7 +128,13 @@ struct PresentedAppError {
 }
 
 struct ErrorToastPayload: Identifiable, Equatable {
+    enum Kind: Equatable {
+        case error
+        case info
+    }
+
     let id: UUID
+    let kind: Kind
     let title: String
     let message: String
     let source: String
@@ -136,12 +142,14 @@ struct ErrorToastPayload: Identifiable, Equatable {
 
     init(
         id: UUID = UUID(),
+        kind: Kind = .error,
         title: String,
         message: String,
         source: String,
         serverName: String?
     ) {
         self.id = id
+        self.kind = kind
         self.title = title
         self.message = message
         self.source = source
@@ -185,6 +193,7 @@ struct ErrorToastOverlay: View {
     var body: some View {
         if let activeToast = errorToastCenter.activeToast {
             ErrorToastView(
+                kind: activeToast.kind,
                 title: activeToast.title,
                 message: activeToast.message,
                 source: activeToast.source,
@@ -292,17 +301,48 @@ private struct ErrorAlertModifier: ViewModifier {
 }
 
 struct ErrorToastView: View {
+    let kind: ErrorToastPayload.Kind
     let title: String
     let message: String
     let source: String
     let serverName: String?
     let dismiss: () -> Void
 
+    init(
+        kind: ErrorToastPayload.Kind = .error,
+        title: String,
+        message: String,
+        source: String,
+        serverName: String?,
+        dismiss: @escaping () -> Void
+    ) {
+        self.kind = kind
+        self.title = title
+        self.message = message
+        self.source = source
+        self.serverName = serverName
+        self.dismiss = dismiss
+    }
+
+    private var iconName: String {
+        switch kind {
+        case .error: return "exclamationmark.triangle.fill"
+        case .info: return "info.circle.fill"
+        }
+    }
+
+    private var accentColor: Color {
+        switch kind {
+        case .error: return .orange
+        case .info: return .accentColor
+        }
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
             HStack(spacing: 8) {
-                Image(systemName: "exclamationmark.triangle.fill")
-                    .foregroundStyle(.orange)
+                Image(systemName: iconName)
+                    .foregroundStyle(accentColor)
                 Text(title)
                     .font(.headline)
                     .lineLimit(1)
@@ -331,7 +371,7 @@ struct ErrorToastView: View {
         .background(.thinMaterial, in: RoundedRectangle(cornerRadius: 10, style: .continuous))
         .overlay(
             RoundedRectangle(cornerRadius: 10, style: .continuous)
-                .strokeBorder(.orange.opacity(0.4), lineWidth: 1)
+                .strokeBorder(accentColor.opacity(0.4), lineWidth: 1)
         )
         .shadow(radius: 8, y: 2)
     }

--- a/Wired 3/App/Wired3App.swift
+++ b/Wired 3/App/Wired3App.swift
@@ -1077,6 +1077,29 @@ private struct AppRootView: View {
                     await startRemoteDownload(for: action.connectionID, remotePath: remotePath)
                 }
             }
+            .onReceive(NotificationCenter.default.publisher(for: .wiredConnectionVersionMismatch)) { note in
+                guard
+                    let info = note.userInfo?["info"] as? ProtocolVersionInfo,
+                    let connectionID = note.userInfo?["connectionID"] as? UUID
+                else { return }
+                let runtime = connectionController.runtime(for: connectionID)
+                let serverName = runtime.map { connectionController.runtimeDisplayName($0) }
+                errorToastCenter.present(
+                    ErrorToastPayload(
+                        kind: .info,
+                        title: String(localized: "Protocol version mismatch"),
+                        message: String(
+                            format: String(
+                                localized: "Client runs Wired %@, server runs %@. The session works, but features only available on one side may be unavailable."
+                            ),
+                            info.localVersion,
+                            info.remoteVersion
+                        ),
+                        source: "Connection",
+                        serverName: serverName
+                    )
+                )
+            }
     }
 
     private func startRemoteDownload(for connectionID: UUID, remotePath: String) async {

--- a/Wired 3/Connection/ConnectionController.swift
+++ b/Wired 3/Connection/ConnectionController.swift
@@ -20,6 +20,10 @@ extension Notification.Name {
     static let wiredAccountAccountsChanged = Notification.Name("wiredAccountAccountsChanged")
     static let wiredServerEventReceived = Notification.Name("wiredServerEventReceived")
     static let wiredServerLogMessageReceived = Notification.Name("wiredServerLogMessageReceived")
+    /// Posted on the main queue right after a successful connect when the
+    /// client and server advertise different Wired protocol versions. The
+    /// userInfo contains `connectionID: UUID` and `info: ProtocolVersionInfo`.
+    static let wiredConnectionVersionMismatch = Notification.Name("wiredConnectionVersionMismatch")
 }
 
 struct RemoteServerEvent {
@@ -2709,7 +2713,7 @@ final class ConnectionController {
         UNUserNotificationCenter.current().add(request)
     }
 
-    private func runtimeDisplayName(_ runtime: ConnectionRuntime?) -> String {
+    func runtimeDisplayName(_ runtime: ConnectionRuntime?) -> String {
         guard let runtime else { return "Server" }
         return withStateLock {
             configurationsByID[runtime.id]?.name ?? "Server"

--- a/Wired 3/Connection/ConnectionRuntime.swift
+++ b/Wired 3/Connection/ConnectionRuntime.swift
@@ -12,6 +12,31 @@ import WiredSwift
 import UniformTypeIdentifiers
 import CryptoKit
 
+/// Snapshot of the Wired protocol versions seen on a connection.
+///
+/// Both sides exchange their full spec via `p7.compatibility_check.specification`
+/// when the versions differ; the resulting diff (`messagesUnknownToRemote`
+/// etc.) lets the UI surface what is unsupported on either side without
+/// blocking the session.
+struct ProtocolVersionInfo: Equatable {
+    let localVersion: String
+    let remoteVersion: String
+    let messagesUnknownToRemote: Int
+    let messagesUnknownToLocal: Int
+    let fieldsUnknownToRemote: Int
+    let fieldsUnknownToLocal: Int
+
+    var hasMismatch: Bool { localVersion != remoteVersion }
+
+    /// `true` if the spec exchange happened and surfaced concrete spec
+    /// items the peer doesn't know about — useful for "feature X may not
+    /// be available" hints in the UI.
+    var hasSpecDrift: Bool {
+        messagesUnknownToRemote + messagesUnknownToLocal +
+        fieldsUnknownToRemote + fieldsUnknownToLocal > 0
+    }
+}
+
 struct ChatInvitation: Equatable {
     let chatID: UInt32
     let inviterUserID: UInt32
@@ -333,6 +358,13 @@ final class ConnectionRuntime: Identifiable {
     var joined = false
     var lastError: Error?
     var moderationNotice: ModerationNotice?
+
+    /// Snapshot of the Wired protocol versions negotiated for this session.
+    /// Populated in `connected(_:)` from the underlying `P7Socket`. `nil`
+    /// while disconnected. Used by `ServerInfoView` and `UserListRowView`
+    /// to surface client/server version drift, and by the connection
+    /// success toast.
+    var protocolVersionInfo: ProtocolVersionInfo?
     var hasConnectionIssue: Bool = false
     var isAutoReconnectScheduled: Bool = false
     var autoReconnectAttempt: Int = 0
@@ -461,8 +493,34 @@ final class ConnectionRuntime: Identifiable {
         lastError = nil
         hasConnectionIssue = false
         status = .connected
+        protocolVersionInfo = Self.versionInfo(from: connection)
         resetAutoReconnectState()
         startTypingCleanupTimer()
+
+        if let info = protocolVersionInfo, info.hasMismatch {
+            NotificationCenter.default.post(
+                name: .wiredConnectionVersionMismatch,
+                object: nil,
+                userInfo: [
+                    "connectionID": id,
+                    "info": info
+                ]
+            )
+        }
+    }
+
+    private static func versionInfo(from connection: Connection) -> ProtocolVersionInfo? {
+        guard let local = connection.spec.protocolVersion else { return nil }
+        let remote = connection.socket?.remoteVersion ?? local
+        let diff = connection.socket?.compatibilityDiff
+        return ProtocolVersionInfo(
+            localVersion: local,
+            remoteVersion: remote,
+            messagesUnknownToRemote: diff?.messagesUnknownToRemote.count ?? 0,
+            messagesUnknownToLocal: diff?.messagesUnknownToLocal.count ?? 0,
+            fieldsUnknownToRemote: diff?.fieldsUnknownToRemote.count ?? 0,
+            fieldsUnknownToLocal: diff?.fieldsUnknownToLocal.count ?? 0
+        )
     }
 
     func disconnect(error: Error? = nil) {
@@ -474,6 +532,7 @@ final class ConnectionRuntime: Identifiable {
         privileges = [:]
         userID = 0
         serverInfo = nil
+        protocolVersionInfo = nil
         status = .disconnected
         pendingChatInvitation = nil
 

--- a/Wired 3/Features/Chats/Views/UserListRowView.swift
+++ b/Wired 3/Features/Chats/Views/UserListRowView.swift
@@ -100,7 +100,11 @@ struct UserInfosView: View {
                     }
                     if let wiredName = spec.protocolName, let wiredVersion = spec.protocolVersion {
                         LabeledContent {
-                            Text("\(wiredName) \(wiredVersion)").foregroundStyle(.secondary)
+                            wiredProtocolLabel(
+                                specName: wiredName,
+                                localVersion: wiredVersion,
+                                info: runtime.protocolVersionInfo
+                            )
                         } label: {
                             Text("Wired Protocol")
                         }
@@ -193,6 +197,42 @@ struct UserInfosView: View {
                 await runtime.refreshUserInfo(user.id)
                 try? await Task.sleep(nanoseconds: 1_000_000_000)
             }
+        }
+    }
+
+    @ViewBuilder
+    private func wiredProtocolLabel(
+        specName: String,
+        localVersion: String,
+        info: ProtocolVersionInfo?
+    ) -> some View {
+        if let info, info.hasMismatch {
+            HStack(spacing: 6) {
+                Text("\(specName) \(info.remoteVersion) (server) · \(info.localVersion) (client)")
+                    .foregroundStyle(.secondary)
+                Image(systemName: "info.circle")
+                    .foregroundStyle(.orange)
+                    .imageScale(.small)
+                    .help(versionDriftSummary(info: info))
+            }
+        } else {
+            Text("\(specName) \(localVersion)").foregroundStyle(.secondary)
+        }
+    }
+
+    private func versionDriftSummary(info: ProtocolVersionInfo) -> String {
+        if info.hasSpecDrift {
+            return String(
+                format: String(
+                    localized: "Spec drift — messages: %d unknown to server, %d unknown to client; fields: %d / %d."
+                ),
+                info.messagesUnknownToRemote,
+                info.messagesUnknownToLocal,
+                info.fieldsUnknownToRemote,
+                info.fieldsUnknownToLocal
+            )
+        } else {
+            return String(localized: "No spec drift — newer features are simply gated by the negotiated version.")
         }
     }
 }

--- a/Wired 3/Features/ServerInfo/Views/ServerInfoView.swift
+++ b/Wired 3/Features/ServerInfo/Views/ServerInfoView.swift
@@ -54,8 +54,9 @@ struct ServerInfoView: View {
                                     if let p7 = spec.builtinProtocolVersion {
                                         infoRow("P7 Protocol", value: p7)
                                     }
-                                    if let name = spec.protocolName, let ver = spec.protocolVersion {
-                                        infoRow("Wired Protocol", value: "\(name) \(ver)")
+                                    if let name = spec.protocolName,
+                                       let ver = spec.protocolVersion {
+                                        wiredProtocolRow(specName: name, localVersion: ver)
                                     }
                                 }
                             }
@@ -128,6 +129,64 @@ struct ServerInfoView: View {
                 .textSelection(.enabled)
                 .frame(maxWidth: .infinity, alignment: .leading)
         }
+    }
+
+    @ViewBuilder
+    private func wiredProtocolRow(specName: String, localVersion: String) -> some View {
+        let info = runtime.protocolVersionInfo
+        let remoteVersion = info?.remoteVersion ?? localVersion
+        let mismatched = info?.hasMismatch ?? false
+        let valueText = mismatched
+            ? "\(specName) \(remoteVersion) (server) · \(localVersion) (client)"
+            : "\(specName) \(localVersion)"
+
+        GridRow {
+            Text(LocalizedStringKey("Wired Protocol"))
+                .foregroundStyle(.secondary)
+                .font(.subheadline)
+                .gridColumnAlignment(.leading)
+                .frame(minWidth: 110, alignment: .leading)
+
+            HStack(spacing: 6) {
+                Text(valueText)
+                    .font(.subheadline)
+                    .textSelection(.enabled)
+                if mismatched {
+                    Image(systemName: "info.circle")
+                        .foregroundStyle(.orange)
+                        .imageScale(.small)
+                        .help(versionMismatchTooltip(info: info))
+                }
+            }
+            .gridColumnAlignment(.leading)
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+
+    private func versionMismatchTooltip(info: ProtocolVersionInfo?) -> String {
+        guard let info else { return "" }
+        var lines: [String] = [
+            String(
+                format: String(localized: "Client Wired %@ ↔ Server Wired %@"),
+                info.localVersion, info.remoteVersion
+            )
+        ]
+        if info.hasSpecDrift {
+            lines.append(
+                String(
+                    format: String(
+                        localized: "Spec drift — messages: %d unknown to server, %d unknown to client; fields: %d / %d."
+                    ),
+                    info.messagesUnknownToRemote,
+                    info.messagesUnknownToLocal,
+                    info.fieldsUnknownToRemote,
+                    info.fieldsUnknownToLocal
+                )
+            )
+        } else {
+            lines.append(String(localized: "No spec drift — newer features are simply gated by the negotiated version."))
+        }
+        return lines.joined(separator: "\n")
     }
 
     @ViewBuilder


### PR DESCRIPTION
## Summary

Companion to [WiredSwift#89](https://github.com/nark/WiredSwift/pull/89). Now that minor-version mismatches are no longer fatal, the client surfaces the drift to the user.

Closes #38.

- A new \`ProtocolVersionInfo\` snapshot lives on \`ConnectionRuntime\`, populated from \`P7Socket.compatibilityDiff\` at connect time and cleared on disconnect.
- The \`ErrorToast*\` system gains a \`.info\` kind (blue accent + info-circle icon) so neutral advisories don't render as red errors.
- On successful connect, when \`localVersion != remoteVersion\` we post \`.wiredConnectionVersionMismatch\` and the app root view presents an info toast that names which side runs which version.
- \`ServerInfoView\` shows both versions in the **Wired Protocol** row when they differ, with an info-circle that exposes the spec drift counts on hover.
- \`UserListRowView\` mirrors the same indicator inline.

## Test plan

- [x] Build green: \`xcodebuild -scheme \"Wired 3\" -destination 'platform=macOS' build\`
- [x] Manual: connect a v3.1 client to a v3.0 server (and reverse) — verify toast appears, ServerInfoView shows both versions, UserListRowView shows the indicator
- [x] Manual: connect to a same-version server — no toast, default version row

🤖 Generated with [Claude Code](https://claude.com/claude-code)