### PR TITLE
feat(chats): emoji reactions on chat messages (Wired 3.2)

### DIFF
--- a/Wired 3/App/SettingsView.swift
+++ b/Wired 3/App/SettingsView.swift
@@ -975,7 +975,7 @@ struct EventsSettingsView: View {
         let connection: [WiredEventTag] = [.serverConnected, .serverDisconnected, .error]
         let activity: [WiredEventTag] = [
             .userJoined, .userChangedNick, .userChangedStatus, .userLeft,
-            .chatReceived, .chatSent, .highlightedChatReceived, .chatInvitationReceived,
+            .chatReceived, .chatSent, .chatReactionReceived, .highlightedChatReceived, .chatInvitationReceived,
             .messageReceived, .broadcastReceived, .boardPostAdded, .boardReactionReceived
         ]
         let transfers: [WiredEventTag] = [.transferStarted, .transferFinished]
@@ -1075,6 +1075,7 @@ struct EventsSettingsView: View {
         case .userLeft: return "person.badge.minus"
         case .chatReceived: return "message"
         case .chatSent: return "paperplane"
+        case .chatReactionReceived: return "face.smiling"
         case .highlightedChatReceived: return "text.bubble"
         case .chatInvitationReceived: return "person.2.badge.plus"
         case .messageReceived: return "envelope.badge"

--- a/Wired 3/Connection/ConnectionController.swift
+++ b/Wired 3/Connection/ConnectionController.swift
@@ -46,6 +46,7 @@ enum WiredEventTag: Int, CaseIterable, Codable, Identifiable {
     case userLeft = 6
     case chatReceived = 7
     case chatSent = 16
+    case chatReactionReceived = 18
     case highlightedChatReceived = 14
     case chatInvitationReceived = 15
     case messageReceived = 8
@@ -66,6 +67,7 @@ enum WiredEventTag: Int, CaseIterable, Codable, Identifiable {
         case .userChangedNick: return "User Changed Nick"
         case .userLeft: return "User Left"
         case .chatReceived: return "Chat Received"
+        case .chatReactionReceived: return "Chat Reaction Received"
         case .messageReceived: return "Message Received"
         case .boardPostAdded: return "Board Post Added"
         case .boardReactionReceived: return "Board Reaction Received"
@@ -89,6 +91,7 @@ enum WiredEventTag: Int, CaseIterable, Codable, Identifiable {
         .userLeft,
         .chatReceived,
         .chatSent,
+        .chatReactionReceived,
         .highlightedChatReceived,
         .chatInvitationReceived,
         .messageReceived,
@@ -1855,10 +1858,22 @@ final class ConnectionController {
                 let added = (message.name == "wired.chat.reaction_added")
                 let nick = message.string(forField: "wired.chat.reaction.nick")
                 await MainActor.run {
-                    runtime.applyChatReactionBroadcast(
+                    let event = runtime.applyChatReactionBroadcast(
                         chatID: chatID, messageID: messageID,
-                        emoji: emoji, count: Int(count), added: added, nick: nick
+                        emoji: emoji, count: Int(count), added: added, nick: nick,
+                        countAsUnread: self.shouldIncrementUnreadForChatMessage(in: runtime, chatID: chatID)
                     )
+
+                    if added, let reactorNick = nick, reactorNick != runtime.currentNick {
+                        let subject = event?.reactionNotificationSubject ?? "a chat message"
+                        self.triggerEvent(
+                            .chatReactionReceived,
+                            runtime: runtime,
+                            subtitle: reactorNick,
+                            body: "\(reactorNick) reacted with \(emoji) to \(subject)",
+                            chatText: nil
+                        )
+                    }
                 }
             }
         case "wired.message.message":

--- a/Wired 3/Connection/ConnectionController.swift
+++ b/Wired 3/Connection/ConnectionController.swift
@@ -1736,10 +1736,13 @@ final class ConnectionController {
                         if let user = await chat.users.first(where: { $0.id == userID }) {
                             if let say = message.string(forField: "wired.chat.say") {
                                 let attachments = ChatAttachmentDescriptor.descriptors(from: message)
+                                let serverMessageID = message.string(forField: "wired.chat.message.id")
                                 await MainActor.run {
                                     runtime.clearIncomingChatTyping(chatID: chatID, userID: userID)
+                                    let event = ChatEvent(chat: chat, user: user, type: .say, text: say, attachments: attachments)
+                                    event.serverMessageID = serverMessageID
                                     appendChatMessage(
-                                        ChatEvent(chat: chat, user: user, type: .say, text: say, attachments: attachments),
+                                        event,
                                         to: chat,
                                         runtime: runtime
                                     )
@@ -1788,10 +1791,13 @@ final class ConnectionController {
                         if let user = await chat.users.first(where: { $0.id == userID }) {
                             if let say = message.string(forField: "wired.chat.me") {
                                 let attachments = ChatAttachmentDescriptor.descriptors(from: message)
+                                let serverMessageID = message.string(forField: "wired.chat.message.id")
                                 await MainActor.run {
                                     runtime.clearIncomingChatTyping(chatID: chatID, userID: userID)
+                                    let event = ChatEvent(chat: chat, user: user, type: .me, text: say, attachments: attachments)
+                                    event.serverMessageID = serverMessageID
                                     appendChatMessage(
-                                        ChatEvent(chat: chat, user: user, type: .me, text: say, attachments: attachments),
+                                        event,
                                         to: chat,
                                         runtime: runtime
                                     )
@@ -1839,6 +1845,20 @@ final class ConnectionController {
                let isTyping = message.bool(forField: "wired.chat.typing") {
                 await MainActor.run {
                     runtime.applyIncomingChatTyping(chatID: chatID, userID: userID, isTyping: isTyping)
+                }
+            }
+        case "wired.chat.reaction_added", "wired.chat.reaction_removed":
+            if let chatID = message.uint32(forField: "wired.chat.id"),
+               let messageID = message.string(forField: "wired.chat.message.id"),
+               let emoji = message.string(forField: "wired.chat.reaction.emoji"),
+               let count = message.uint32(forField: "wired.chat.reaction.count") {
+                let added = (message.name == "wired.chat.reaction_added")
+                let nick = message.string(forField: "wired.chat.reaction.nick")
+                await MainActor.run {
+                    runtime.applyChatReactionBroadcast(
+                        chatID: chatID, messageID: messageID,
+                        emoji: emoji, count: Int(count), added: added, nick: nick
+                    )
                 }
             }
         case "wired.message.message":

--- a/Wired 3/Connection/ConnectionRuntime+ChatReactions.swift
+++ b/Wired 3/Connection/ConnectionRuntime+ChatReactions.swift
@@ -72,11 +72,25 @@ extension ConnectionRuntime {
 
     /// Apply an incoming `wired.chat.reaction_added` / `reaction_removed`
     /// to the in-memory event. Mirrors `applyReactionBroadcast` for boards.
+    @discardableResult
     func applyChatReactionBroadcast(chatID: UInt32, messageID: String,
-                                    emoji: String, count: Int, added: Bool, nick: String?) {
-        guard let event = chatEvent(chatID: chatID, messageID: messageID) else { return }
+                                    emoji: String, count: Int, added: Bool,
+                                    nick: String?, countAsUnread: Bool) -> ChatEvent? {
+        guard let chat = chat(withID: chatID) else { return nil }
+        let event = chatEvent(chatID: chatID, messageID: messageID)
 
         let isOwnReaction = nick == nil || nick == currentNick
+
+        if added, !isOwnReaction, countAsUnread {
+            chat.unreadReactionCount += 1
+            connectionController.updateNotificationsBadge()
+        }
+        if !added, !isOwnReaction, chat.unreadReactionCount > 0 {
+            chat.unreadReactionCount -= 1
+            connectionController.updateNotificationsBadge()
+        }
+
+        guard let event else { return nil }
 
         if count == 0 {
             event.reactions.removeAll { $0.emoji == emoji }
@@ -107,5 +121,7 @@ extension ConnectionRuntime {
                 captured.newReactionEmojis.remove(capturedEmoji)
             }
         }
+
+        return event
     }
 }

--- a/Wired 3/Connection/ConnectionRuntime+ChatReactions.swift
+++ b/Wired 3/Connection/ConnectionRuntime+ChatReactions.swift
@@ -1,0 +1,111 @@
+//
+//  ConnectionRuntime+ChatReactions.swift
+//  Wired-macOS
+//
+//  Wired 3.2 chat-reactions runtime helpers, factored out of
+//  ConnectionRuntime to keep that type's body length under SwiftLint
+//  thresholds.
+//
+
+import Foundation
+import WiredSwift
+
+extension ConnectionRuntime {
+
+    /// Whether the connected peer advertises the 3.2 chat-reactions surface.
+    var canUseChatReactions: Bool {
+        connection?.socket.peerKnows(messageNamed: "wired.chat.add_reaction") ?? false
+    }
+
+    private func chatEvent(chatID: UInt32, messageID: String) -> ChatEvent? {
+        guard let chat = chat(withID: chatID) else { return nil }
+        return chat.messages.first { $0.serverMessageID == messageID && $0.type != .event }
+    }
+
+    /// Lazy fetch of reaction summaries for a chat message. Safe to call
+    /// repeatedly: results overwrite `event.reactions` and flag
+    /// `reactionsLoaded`.
+    func getChatReactions(for event: ChatEvent) async throws {
+        guard let messageID = event.serverMessageID else { return }
+        guard let connection = connection as? AsyncConnection else {
+            throw AsyncConnectionError.notConnected
+        }
+
+        let m = P7Message(withName: "wired.chat.get_reactions", spec: spec)
+        m.addParameter(field: "wired.chat.id", value: event.chat.id)
+        m.addParameter(field: "wired.chat.message.id", value: messageID)
+
+        var summaries: [ChatReactionSummary] = []
+        for try await response in try connection.sendAndWaitMany(m) {
+            guard response.name == "wired.chat.reaction_list",
+                  let emoji = response.string(forField: "wired.chat.reaction.emoji"),
+                  let count = response.uint32(forField: "wired.chat.reaction.count"),
+                  let isOwn = response.bool(forField: "wired.chat.reaction.is_own")
+            else { continue }
+            let nicksStr = response.string(forField: "wired.chat.reaction.nicks") ?? ""
+            let nicks = nicksStr.isEmpty ? [] : nicksStr.components(separatedBy: "|")
+            summaries.append(ChatReactionSummary(emoji: emoji, count: Int(count), isOwn: isOwn, nicks: nicks))
+        }
+        event.reactions = summaries
+        event.reactionsLoaded = true
+    }
+
+    /// Toggle a reaction. If the user already owns this emoji on the
+    /// message, sends `remove_reaction`; otherwise `add_reaction`. The
+    /// authoritative state arrives via the `reaction_added` /
+    /// `reaction_removed` broadcast.
+    func toggleChatReaction(emoji: String, on event: ChatEvent) async throws {
+        guard let messageID = event.serverMessageID else { return }
+        let isRemoval = event.reactions.first(where: { $0.emoji == emoji })?.isOwn == true
+        let messageName = isRemoval ? "wired.chat.remove_reaction" : "wired.chat.add_reaction"
+
+        let m = P7Message(withName: messageName, spec: spec)
+        m.addParameter(field: "wired.chat.id", value: event.chat.id)
+        m.addParameter(field: "wired.chat.message.id", value: messageID)
+        m.addParameter(field: "wired.chat.reaction.emoji", value: emoji)
+        if let response = try await send(m), response.name == "wired.error" {
+            throw WiredError(message: response)
+        }
+        // Refresh so isOwn is accurate even when our broadcast races our reply.
+        try? await getChatReactions(for: event)
+    }
+
+    /// Apply an incoming `wired.chat.reaction_added` / `reaction_removed`
+    /// to the in-memory event. Mirrors `applyReactionBroadcast` for boards.
+    func applyChatReactionBroadcast(chatID: UInt32, messageID: String,
+                                    emoji: String, count: Int, added: Bool, nick: String?) {
+        guard let event = chatEvent(chatID: chatID, messageID: messageID) else { return }
+
+        let isOwnReaction = nick == nil || nick == currentNick
+
+        if count == 0 {
+            event.reactions.removeAll { $0.emoji == emoji }
+        } else if let idx = event.reactions.firstIndex(where: { $0.emoji == emoji }) {
+            var nicks = event.reactions[idx].nicks
+            if added, let n = nick, !nicks.contains(n) { nicks.append(n) }
+            event.reactions[idx] = ChatReactionSummary(
+                emoji: emoji,
+                count: count,
+                isOwn: event.reactions[idx].isOwn,
+                nicks: nicks
+            )
+        } else if added {
+            event.reactions.append(ChatReactionSummary(
+                emoji: emoji, count: count,
+                isOwn: isOwnReaction && nick == currentNick,
+                nicks: nick.map { [$0] } ?? []
+            ))
+        }
+        event.reactionsLoaded = true
+
+        if added, !isOwnReaction {
+            event.newReactionEmojis.insert(emoji)
+            let captured = event
+            let capturedEmoji = emoji
+            Task { @MainActor in
+                try? await Task.sleep(for: .milliseconds(800))
+                captured.newReactionEmojis.remove(capturedEmoji)
+            }
+        }
+    }
+}

--- a/Wired 3/Connection/ConnectionRuntime.swift
+++ b/Wired 3/Connection/ConnectionRuntime.swift
@@ -436,7 +436,7 @@ final class ConnectionRuntime: Identifiable {
     }
 
     var totalUnreadChatMessages: Int {
-        (chats + private_chats).reduce(0) { $0 + $1.unreadMessagesCount }
+        (chats + private_chats).reduce(0) { $0 + $1.totalUnreadCount }
     }
 
     var totalUnreadPrivateMessages: Int {
@@ -3283,6 +3283,7 @@ final class ConnectionRuntime: Identifiable {
 
     public func resetUnreads(_ chat: Chat) {
         chat.unreadMessagesCount = 0
+        chat.unreadReactionCount = 0
         connectionController.updateNotificationsBadge()
     }
 

--- a/Wired 3/Features/Boards/Views/EmojiPickerPopover.swift
+++ b/Wired 3/Features/Boards/Views/EmojiPickerPopover.swift
@@ -12,17 +12,21 @@ public struct EmojiPickerPopover: View {
     let onSelect: (String) -> Void
 
     @State private var searchText = ""
+    @State private var hasLoadedLibrary = false
 
     private static let quickEmojis = ["👍", "👎", "❤️", "😂", "😮", "🎉", "🤔", "🔥", "👀", "✅"]
     private static let columns     = Array(repeating: GridItem(.flexible(), spacing: 1), count: 8)
+    private static let searchableEmojis = EmojiLibrary.categories
+        .flatMap(\.emojis)
+        .map { emoji in (emoji: emoji, terms: emoji.emojiSearchTerms) }
 
     /// Flat filtered list used while a search query is active.
     private var searchResults: [String] {
         let q = searchText.lowercased()
         guard !q.isEmpty else { return [] }
-        return EmojiLibrary.categories.flatMap(\.emojis).filter {
-            $0.emojiSearchTerms.contains(q)
-        }
+        return Self.searchableEmojis
+            .filter { $0.terms.contains(q) }
+            .map(\.emoji)
     }
 
     public var body: some View {
@@ -61,30 +65,41 @@ public struct EmojiPickerPopover: View {
 
                 Divider()
 
-                // ── Full library, sectioned ───────────────────────────
-                ScrollView(.vertical) {
-                    LazyVGrid(columns: Self.columns, spacing: 1, pinnedViews: .sectionHeaders) {
-                        ForEach(EmojiLibrary.categories) { section in
-                            Section {
-                                ForEach(section.emojis, id: \.self) { emoji in
-                                    emojiCell(emoji)
+                if hasLoadedLibrary {
+                    // ── Full library, sectioned ───────────────────────────
+                    ScrollView(.vertical) {
+                        LazyVGrid(columns: Self.columns, spacing: 1) {
+                            ForEach(EmojiLibrary.categories) { section in
+                                Section {
+                                    ForEach(section.emojis, id: \.self) { emoji in
+                                        emojiCell(emoji)
+                                    }
+                                } header: {
+                                    Text(section.name)
+                                        .font(.system(size: 10, weight: .semibold))
+                                        .foregroundStyle(.secondary)
+                                        .frame(maxWidth: .infinity, alignment: .leading)
+                                        .padding(.horizontal, 6)
+                                        .padding(.top, 8)
+                                        .padding(.bottom, 3)
+                                        .background(Color(nsColor: .windowBackgroundColor))
                                 }
-                            } header: {
-                                Text(section.name)
-                                    .font(.system(size: 10, weight: .semibold))
-                                    .foregroundStyle(.secondary)
-                                    .frame(maxWidth: .infinity, alignment: .leading)
-                                    .padding(.horizontal, 6)
-                                    .padding(.top, 8)
-                                    .padding(.bottom, 3)
-                                    .background(Color(nsColor: .windowBackgroundColor))
                             }
                         }
+                        .padding(.horizontal, 4)
+                        .padding(.bottom, 6)
                     }
-                    .padding(.horizontal, 4)
-                    .padding(.bottom, 6)
+                    .frame(height: 300)
+                } else {
+                    ProgressView()
+                        .controlSize(.small)
+                        .frame(maxWidth: .infinity)
+                        .frame(height: 300)
+                        .task {
+                            try? await Task.sleep(for: .milliseconds(80))
+                            hasLoadedLibrary = true
+                        }
                 }
-                .frame(height: 300)
             } else {
                 // ── Search results ────────────────────────────────────
                 ScrollView(.vertical) {
@@ -125,7 +140,6 @@ public struct EmojiPickerPopover: View {
                 )
         }
         .buttonStyle(.plain)
-        .pointerOnHover()
     }
 }
 

--- a/Wired 3/Features/Chats/Views/ChatMeMessageView.swift
+++ b/Wired 3/Features/Chats/Views/ChatMeMessageView.swift
@@ -46,6 +46,7 @@ struct ChatMeMessageView: View {
                     .frame(maxWidth: .infinity)
                     .foregroundStyle(.gray)
                     .font(.caption)
+                    .chatReactionGesture(for: message, allowDoubleClick: true)
 
                 Spacer()
 
@@ -73,6 +74,7 @@ struct ChatMeMessageView: View {
                             onOpenQuickLook?(source)
                         }
                     )
+                    .chatReactionGesture(for: message)
                     Spacer()
                 }
             }
@@ -81,9 +83,12 @@ struct ChatMeMessageView: View {
                 HStack {
                     Spacer()
                     ChatAttachmentFileBubbleView(attachment: attachment, isFromYou: false, showsTail: false)
+                        .chatReactionGesture(for: message)
                     Spacer()
                 }
             }
+
+            ChatReactionBarView(event: message)
         }
         .listRowSeparator(.hidden)
         .id(message.id)

--- a/Wired 3/Features/Chats/Views/ChatReactionBarView.swift
+++ b/Wired 3/Features/Chats/Views/ChatReactionBarView.swift
@@ -1,0 +1,190 @@
+//
+//  ChatReactionBarView.swift
+//  Wired-macOS
+//
+//  Wired 3.2 chat-message reaction surface. Mirrors the board reactions
+//  bar (ReactionBarView / ReactionChipView) but operates on ChatEvent
+//  and the new wired.chat.reaction.* messages. Hidden entirely when the
+//  peer doesn't advertise wired.chat.add_reaction so 3.1 servers degrade
+//  cleanly.
+//
+
+import SwiftUI
+
+struct ChatReactionBarView: View {
+    @Environment(ConnectionRuntime.self) private var runtime
+    let event: ChatEvent
+    /// Hover state from the parent message row. The "+" picker is hidden
+    /// until the user hovers, to avoid cluttering the chat with always-on
+    /// affordances.
+    var isParentHovered: Bool = false
+
+    @State private var showEmojiPicker = false
+
+    private var canReact: Bool {
+        runtime.canUseChatReactions && event.serverMessageID != nil
+    }
+
+    var body: some View {
+        if canReact, !event.reactions.isEmpty || isParentHovered {
+            HStack(spacing: 6) {
+                ForEach(event.reactions) { reaction in
+                    ChatReactionChipView(
+                        reaction: reaction,
+                        allReactions: event.reactions,
+                        isNew: event.newReactionEmojis.contains(reaction.emoji),
+                        onToggle: { emoji in toggle(emoji) }
+                    )
+                }
+                addButton
+            }
+            .animation(.easeInOut(duration: 0.15), value: event.reactions.map(\.count))
+            .task(id: event.serverMessageID ?? "") {
+                guard !event.reactionsLoaded, event.serverMessageID != nil else { return }
+                try? await runtime.getChatReactions(for: event)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var addButton: some View {
+        Button { showEmojiPicker = true } label: {
+            Image(systemName: "face.smiling")
+                .font(.system(size: 12))
+                .foregroundStyle(.secondary)
+                .padding(.horizontal, 6)
+                .padding(.vertical, 2)
+                .background(Capsule().fill(Color.secondary.opacity(0.08)))
+                .overlay(Capsule().strokeBorder(Color.secondary.opacity(0.2), lineWidth: 1))
+        }
+        .buttonStyle(.plain)
+        .help("Add a reaction")
+        .popover(isPresented: $showEmojiPicker, arrowEdge: .bottom) {
+            EmojiPickerPopover { emoji in
+                showEmojiPicker = false
+                toggle(emoji)
+            }
+        }
+    }
+
+    private func toggle(_ emoji: String) {
+        Task { try? await runtime.toggleChatReaction(emoji: emoji, on: event) }
+    }
+}
+
+private struct ChatReactionChipView: View {
+    let reaction: ChatReactionSummary
+    let allReactions: [ChatReactionSummary]
+    var isNew: Bool = false
+    let onToggle: (String) -> Void
+
+    @State private var showPopover = false
+    @State private var hoverTask: Task<Void, Never>?
+    @State private var shake: CGFloat = 0
+
+    var body: some View {
+        Button { onToggle(reaction.emoji) } label: {
+            HStack(spacing: 4) {
+                Text(reaction.emoji).font(.system(size: 13))
+                Text("\(reaction.count)")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(reaction.isOwn ? .white : .primary)
+            }
+            .padding(.horizontal, 7)
+            .padding(.vertical, 2)
+            .background(
+                Capsule().fill(reaction.isOwn ? Color.accentColor : Color.secondary.opacity(0.12))
+            )
+            .overlay(
+                Capsule().strokeBorder(
+                    reaction.isOwn ? Color.accentColor : Color.secondary.opacity(0.25),
+                    lineWidth: 1
+                )
+            )
+        }
+        .buttonStyle(.plain)
+        .offset(x: shake)
+        .onChange(of: isNew) { _, v in if v { performShake() } }
+        .onHover { hovering in
+            hoverTask?.cancel()
+            if hovering {
+                hoverTask = Task {
+                    try? await Task.sleep(for: .milliseconds(500))
+                    guard !Task.isCancelled else { return }
+                    showPopover = true
+                }
+            } else {
+                showPopover = false
+            }
+        }
+        .popover(isPresented: $showPopover, arrowEdge: .bottom) {
+            ChatReactionSummaryPopover(reactions: allReactions)
+        }
+        .contextMenu {
+            Button(reaction.isOwn ? "Remove your reaction" : "React with \(reaction.emoji)") {
+                onToggle(reaction.emoji)
+            }
+        }
+    }
+
+    private func performShake() {
+        let step = 0.07
+        withAnimation(.easeInOut(duration: step)) { shake = -4 }
+        DispatchQueue.main.asyncAfter(deadline: .now() + step * 1) {
+            withAnimation(.easeInOut(duration: step)) { shake =  4 }
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + step * 2) {
+            withAnimation(.easeInOut(duration: step)) { shake = -3 }
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + step * 3) {
+            withAnimation(.easeInOut(duration: step)) { shake =  2 }
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + step * 4) {
+            withAnimation(.easeInOut(duration: step)) { shake =  0 }
+        }
+    }
+}
+
+private struct ChatReactionSummaryPopover: View {
+    let reactions: [ChatReactionSummary]
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Text("Reactions")
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.secondary)
+                .padding(.horizontal, 14).padding(.top, 12).padding(.bottom, 8)
+            Divider()
+            ScrollView {
+                VStack(alignment: .leading, spacing: 0) {
+                    ForEach(reactions) { reaction in
+                        HStack(alignment: .top, spacing: 10) {
+                            Text(reaction.emoji).font(.title3).frame(width: 28, alignment: .center)
+                            VStack(alignment: .leading, spacing: 2) {
+                                HStack(spacing: 6) {
+                                    Text("\(reaction.count) reaction\(reaction.count == 1 ? "" : "s")")
+                                        .font(.subheadline.weight(.medium))
+                                    if reaction.isOwn {
+                                        Circle().fill(Color.accentColor).frame(width: 5, height: 5)
+                                    }
+                                }
+                                if !reaction.nicks.isEmpty {
+                                    Text(reaction.nicks.joined(separator: ", "))
+                                        .font(.caption).foregroundStyle(.secondary)
+                                        .fixedSize(horizontal: false, vertical: true)
+                                }
+                            }
+                            Spacer(minLength: 0)
+                        }
+                        .padding(.horizontal, 14).padding(.vertical, 7)
+                        if reaction.id != reactions.last?.id {
+                            Divider().padding(.leading, 52)
+                        }
+                    }
+                }
+            }
+            .frame(maxHeight: 240)
+        }
+        .frame(width: 230)
+        .padding(.bottom, 6)
+    }
+}

--- a/Wired 3/Features/Chats/Views/ChatReactionBarView.swift
+++ b/Wired 3/Features/Chats/Views/ChatReactionBarView.swift
@@ -57,6 +57,7 @@ struct ChatReactionLongPressModifier: ViewModifier {
     let allowDoubleClick: Bool
 
     @State private var showPicker = false
+    @State private var isSelectionPending = false
 
     private var canReact: Bool {
         runtime.canUseChatReactions && event.serverMessageID != nil
@@ -66,20 +67,41 @@ struct ChatReactionLongPressModifier: ViewModifier {
         if canReact {
             let withLongPress = content
                 .contentShape(Rectangle())
-                .onLongPressGesture(minimumDuration: 0.4) { showPicker = true }
-                .popover(isPresented: $showPicker, arrowEdge: .top) {
+                .onLongPressGesture(minimumDuration: 0.4) {
+                    guard !isSelectionPending else { return }
+                    showPicker = true
+                }
+                .popover(
+                    isPresented: $showPicker,
+                    attachmentAnchor: .rect(.bounds),
+                    arrowEdge: .bottom
+                ) {
                     EmojiPickerPopover { emoji in
-                        showPicker = false
-                        Task { try? await runtime.toggleChatReaction(emoji: emoji, on: event) }
+                        selectEmoji(emoji)
                     }
                 }
             if allowDoubleClick {
-                withLongPress.onTapGesture(count: 2) { showPicker = true }
+                withLongPress.onTapGesture(count: 2) {
+                    guard !isSelectionPending else { return }
+                    showPicker = true
+                }
             } else {
                 withLongPress
             }
         } else {
             content
+        }
+    }
+
+    private func selectEmoji(_ emoji: String) {
+        guard !isSelectionPending else { return }
+        isSelectionPending = true
+        showPicker = false
+
+        Task { @MainActor in
+            try? await Task.sleep(for: .milliseconds(120))
+            try? await runtime.toggleChatReaction(emoji: emoji, on: event)
+            isSelectionPending = false
         }
     }
 }
@@ -113,11 +135,11 @@ private struct ChatReactionChipView: View {
             .padding(.horizontal, 7)
             .padding(.vertical, 2)
             .background(
-                Capsule().fill(reaction.isOwn ? Color.accentColor : Color.secondary.opacity(0.12))
+                Capsule().fill(chipBackgroundColor)
             )
             .overlay(
                 Capsule().strokeBorder(
-                    reaction.isOwn ? Color.accentColor : Color.secondary.opacity(0.25),
+                    reaction.isOwn ? Color.accentColor : Color(nsColor: .separatorColor),
                     lineWidth: 1
                 )
             )
@@ -145,6 +167,10 @@ private struct ChatReactionChipView: View {
                 onToggle(reaction.emoji)
             }
         }
+    }
+
+    private var chipBackgroundColor: Color {
+        reaction.isOwn ? Color.accentColor : Color(nsColor: .controlBackgroundColor)
     }
 
     private func performShake() {

--- a/Wired 3/Features/Chats/Views/ChatReactionBarView.swift
+++ b/Wired 3/Features/Chats/Views/ChatReactionBarView.swift
@@ -14,19 +14,13 @@ import SwiftUI
 struct ChatReactionBarView: View {
     @Environment(ConnectionRuntime.self) private var runtime
     let event: ChatEvent
-    /// Hover state from the parent message row. The "+" picker is hidden
-    /// until the user hovers, to avoid cluttering the chat with always-on
-    /// affordances.
-    var isParentHovered: Bool = false
-
-    @State private var showEmojiPicker = false
 
     private var canReact: Bool {
         runtime.canUseChatReactions && event.serverMessageID != nil
     }
 
     var body: some View {
-        if canReact, !event.reactions.isEmpty || isParentHovered {
+        if canReact, !event.reactions.isEmpty {
             HStack(spacing: 6) {
                 ForEach(event.reactions) { reaction in
                     ChatReactionChipView(
@@ -36,7 +30,6 @@ struct ChatReactionBarView: View {
                         onToggle: { emoji in toggle(emoji) }
                     )
                 }
-                addButton
             }
             .animation(.easeInOut(duration: 0.15), value: event.reactions.map(\.count))
             .task(id: event.serverMessageID ?? "") {
@@ -46,29 +39,56 @@ struct ChatReactionBarView: View {
         }
     }
 
-    @ViewBuilder
-    private var addButton: some View {
-        Button { showEmojiPicker = true } label: {
-            Image(systemName: "face.smiling")
-                .font(.system(size: 12))
-                .foregroundStyle(.secondary)
-                .padding(.horizontal, 6)
-                .padding(.vertical, 2)
-                .background(Capsule().fill(Color.secondary.opacity(0.08)))
-                .overlay(Capsule().strokeBorder(Color.secondary.opacity(0.2), lineWidth: 1))
-        }
-        .buttonStyle(.plain)
-        .help("Add a reaction")
-        .popover(isPresented: $showEmojiPicker, arrowEdge: .bottom) {
-            EmojiPickerPopover { emoji in
-                showEmojiPicker = false
-                toggle(emoji)
-            }
-        }
-    }
-
     private func toggle(_ emoji: String) {
         Task { try? await runtime.toggleChatReaction(emoji: emoji, on: event) }
+    }
+}
+
+/// Long-press handler that opens the chat reaction picker. Use on any
+/// bubble (text, image, file) — long-press never collides with the
+/// existing single/double-tap actions on image bubbles. The popover and
+/// the toggle action are owned by the modifier so the gesture surface
+/// stays self-contained.
+struct ChatReactionLongPressModifier: ViewModifier {
+    @Environment(ConnectionRuntime.self) private var runtime
+    let event: ChatEvent
+    /// When true, double-click also opens the picker (text bubbles only —
+    /// image bubbles use double-click to open QuickLook).
+    let allowDoubleClick: Bool
+
+    @State private var showPicker = false
+
+    private var canReact: Bool {
+        runtime.canUseChatReactions && event.serverMessageID != nil
+    }
+
+    func body(content: Content) -> some View {
+        if canReact {
+            let withLongPress = content
+                .contentShape(Rectangle())
+                .onLongPressGesture(minimumDuration: 0.4) { showPicker = true }
+                .popover(isPresented: $showPicker, arrowEdge: .top) {
+                    EmojiPickerPopover { emoji in
+                        showPicker = false
+                        Task { try? await runtime.toggleChatReaction(emoji: emoji, on: event) }
+                    }
+                }
+            if allowDoubleClick {
+                withLongPress.onTapGesture(count: 2) { showPicker = true }
+            } else {
+                withLongPress
+            }
+        } else {
+            content
+        }
+    }
+}
+
+extension View {
+    /// Reaction picker on long-press (every bubble) and optionally on
+    /// double-click (text bubbles, where double-click is otherwise unused).
+    func chatReactionGesture(for event: ChatEvent, allowDoubleClick: Bool = false) -> some View {
+        modifier(ChatReactionLongPressModifier(event: event, allowDoubleClick: allowDoubleClick))
     }
 }
 

--- a/Wired 3/Features/Chats/Views/ChatRowView.swift
+++ b/Wired 3/Features/Chats/Views/ChatRowView.swift
@@ -40,7 +40,7 @@ struct ChatRowView: View {
 
             Spacer()
 
-            UnreadCountBadge(count: chat.unreadMessagesCount)
+            UnreadCountBadge(count: chat.totalUnreadCount)
         }
         .contentShape(Rectangle())
 #if os(macOS)

--- a/Wired 3/Features/Chats/Views/ChatSayMessageView.swift
+++ b/Wired 3/Features/Chats/Views/ChatSayMessageView.swift
@@ -80,7 +80,7 @@ struct ChatSayMessageView: View {
                             bubbleFillColor: bubbleFillColor,
                             bubbleTextColor: bubbleTextColor
                         )
-                        ChatReactionBarView(event: message, isParentHovered: isHovered)
+                        ChatReactionBarView(event: message)
                             .padding(.trailing, 10)
                     }
                     .padding(.bottom, isGroupedWithNext ? 2 : 8)
@@ -106,7 +106,7 @@ struct ChatSayMessageView: View {
                             bubbleFillColor: bubbleFillColor,
                             bubbleTextColor: bubbleTextColor
                         )
-                        ChatReactionBarView(event: message, isParentHovered: isHovered)
+                        ChatReactionBarView(event: message)
                             .padding(.leading, 10)
                     }
                     .padding(.bottom, isGroupedWithNext ? 2 : 8)
@@ -156,6 +156,7 @@ struct ChatSayMessageView: View {
                 Text(trimmedMessageText)
                     .font(.system(size: 52))
                     .padding(.horizontal, 4)
+                    .chatReactionGesture(for: message, allowDoubleClick: true)
             } else if shouldShowTextBubble {
                 Text(message.text.attributedWithDetectedLinks(linkColor: linkColor))
                     .messageBubbleStyle(
@@ -171,6 +172,7 @@ struct ChatSayMessageView: View {
                         spacing: 0,
                         alignment: isFromYou ? .trailing : .leading
                     )
+                    .chatReactionGesture(for: message, allowDoubleClick: true)
             }
 
             if let primaryImageURL {
@@ -187,6 +189,7 @@ struct ChatSayMessageView: View {
                         onOpenQuickLook?(source)
                     }
                 )
+                .chatReactionGesture(for: message)
             }
 
             ForEach(Array(imageAttachments.enumerated()), id: \.element.id) { index, attachment in
@@ -203,6 +206,7 @@ struct ChatSayMessageView: View {
                         onOpenQuickLook?(source)
                     }
                 )
+                .chatReactionGesture(for: message)
             }
 
             ForEach(Array(fileAttachments.enumerated()), id: \.element.id) { index, attachment in
@@ -211,6 +215,7 @@ struct ChatSayMessageView: View {
                     isFromYou: isFromYou,
                     showsTail: index == fileAttachments.count - 1 && !isGroupedWithNext
                 )
+                .chatReactionGesture(for: message)
             }
         }
     }

--- a/Wired 3/Features/Chats/Views/ChatSayMessageView.swift
+++ b/Wired 3/Features/Chats/Views/ChatSayMessageView.swift
@@ -80,6 +80,8 @@ struct ChatSayMessageView: View {
                             bubbleFillColor: bubbleFillColor,
                             bubbleTextColor: bubbleTextColor
                         )
+                        ChatReactionBarView(event: message, isParentHovered: isHovered)
+                            .padding(.trailing, 10)
                     }
                     .padding(.bottom, isGroupedWithNext ? 2 : 8)
                     .alignmentGuide(.bottom) { d in isEmojiOnlyMessage ? d[VerticalAlignment.center] : d[.bottom] }
@@ -104,6 +106,8 @@ struct ChatSayMessageView: View {
                             bubbleFillColor: bubbleFillColor,
                             bubbleTextColor: bubbleTextColor
                         )
+                        ChatReactionBarView(event: message, isParentHovered: isHovered)
+                            .padding(.leading, 10)
                     }
                     .padding(.bottom, isGroupedWithNext ? 2 : 8)
                     .alignmentGuide(.bottom) { d in isEmojiOnlyMessage ? d[VerticalAlignment.center] : d[.bottom] }

--- a/Wired 3/Features/Chats/Views/ChatSayMessageView.swift
+++ b/Wired 3/Features/Chats/Views/ChatSayMessageView.swift
@@ -62,8 +62,12 @@ struct ChatSayMessageView: View {
         let bubbleFillColor = matchedRule?.color.swiftUIColor
         let bubbleTextColor = matchedRule?.color.contrastTextColor
         let linkColor = bubbleTextColor ?? (isFromYou ? .white : .blue)
+        let baseBottomSpacing: CGFloat = isGroupedWithNext ? 2 : 8
+        let hasReactions = !message.reactions.isEmpty
+        let bubbleStackBottomSpacing: CGFloat = hasReactions ? 0 : baseBottomSpacing
+        let reactionMessageBottomSpacing: CGFloat = hasReactions ? 12 : 0
 
-        VStack(alignment: isFromYou ? .trailing : .leading) {
+        VStack(alignment: isFromYou ? .trailing : .leading, spacing: 0) {
             HStack(alignment: .bottom) {
                 if isFromYou {
                     Spacer()
@@ -81,9 +85,12 @@ struct ChatSayMessageView: View {
                             bubbleTextColor: bubbleTextColor
                         )
                         ChatReactionBarView(event: message)
-                            .padding(.trailing, 10)
+                            .padding(.trailing, 22)
+                            .padding(.top, -14)
+                            .padding(.bottom, 2)
+                            .zIndex(1)
                     }
-                    .padding(.bottom, isGroupedWithNext ? 2 : 8)
+                    .padding(.bottom, bubbleStackBottomSpacing)
                     .alignmentGuide(.bottom) { d in isEmojiOnlyMessage ? d[VerticalAlignment.center] : d[.bottom] }
 
                     avatarView
@@ -107,9 +114,12 @@ struct ChatSayMessageView: View {
                             bubbleTextColor: bubbleTextColor
                         )
                         ChatReactionBarView(event: message)
-                            .padding(.leading, 10)
+                            .padding(.leading, 22)
+                            .padding(.top, -14)
+                            .padding(.bottom, 2)
+                            .zIndex(1)
                     }
-                    .padding(.bottom, isGroupedWithNext ? 2 : 8)
+                    .padding(.bottom, bubbleStackBottomSpacing)
                     .alignmentGuide(.bottom) { d in isEmojiOnlyMessage ? d[VerticalAlignment.center] : d[.bottom] }
                     Spacer()
                 }
@@ -124,6 +134,7 @@ struct ChatSayMessageView: View {
                     .padding(isFromYou ? .trailing : .leading, 45)
             }
         }
+        .padding(.bottom, reactionMessageBottomSpacing)
         .listRowSeparator(.hidden)
         .listRowInsets(EdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0))
         .id(message.id)
@@ -165,6 +176,7 @@ struct ChatSayMessageView: View {
                         customForegroundColor: bubbleTextColor,
                         showsTail: primaryImageURL == nil && imageAttachments.isEmpty && fileAttachments.isEmpty && !isGroupedWithNext
                     )
+                    .chatReactionGesture(for: message, allowDoubleClick: true)
                     .containerRelativeFrame(
                         .horizontal,
                         count: 4,
@@ -172,7 +184,6 @@ struct ChatSayMessageView: View {
                         spacing: 0,
                         alignment: isFromYou ? .trailing : .leading
                     )
-                    .chatReactionGesture(for: message, allowDoubleClick: true)
             }
 
             if let primaryImageURL {

--- a/Wired 3/Features/Chats/Views/ChatView.swift
+++ b/Wired 3/Features/Chats/Views/ChatView.swift
@@ -240,7 +240,7 @@ struct ChatView: View {
     private func markCurrentChatAsReadIfNeeded() {
         guard runtime.selectedTab == .chats else { return }
         guard runtime.selectedChatID == chat.id else { return }
-        guard chat.unreadMessagesCount > 0 else { return }
+        guard chat.totalUnreadCount > 0 else { return }
         runtime.resetUnreads(chat)
     }
 

--- a/Wired 3/Features/ServerSettings/Views/AccountsSettingsView.swift
+++ b/Wired 3/Features/ServerSettings/Views/AccountsSettingsView.swift
@@ -9,6 +9,11 @@ private func accountPrivilegesIncludingColorFromSpec() -> [String] {
         privileges.append("wired.account.color")
     }
 
+    if spec.fieldsByName["wired.account.chat.add_reactions"] != nil,
+       !privileges.contains("wired.account.chat.add_reactions") {
+        privileges.append("wired.account.chat.add_reactions")
+    }
+
     return privileges
 }
 

--- a/Wired 3/Features/ServerSettings/Views/AccountsSettingsView.swift
+++ b/Wired 3/Features/ServerSettings/Views/AccountsSettingsView.swift
@@ -1406,6 +1406,7 @@ private struct AccountPermissionsForm: View {
 
 private enum PermissionCategory: String, CaseIterable, Hashable {
     case basic
+    case chat
     case files
     case messages
     case transfers
@@ -1418,12 +1419,13 @@ private enum PermissionCategory: String, CaseIterable, Hashable {
     case other
 
     static var displayOrder: [PermissionCategory] {
-        [.basic, .files, .messages, .transfers, .boards, .users, .accounts, .administration, .tracker, .limits, .other]
+        [.basic, .chat, .files, .messages, .transfers, .boards, .users, .accounts, .administration, .tracker, .limits, .other]
     }
 
     var title: String {
         switch self {
         case .basic: return NSLocalizedString("Basic", comment: "")
+        case .chat: return NSLocalizedString("Chat", comment: "")
         case .files: return NSLocalizedString("Files", comment: "")
         case .messages: return NSLocalizedString("Messages", comment: "")
         case .transfers: return NSLocalizedString("Transfers", comment: "")
@@ -1439,11 +1441,15 @@ private enum PermissionCategory: String, CaseIterable, Hashable {
 
     static func category(for key: String) -> PermissionCategory {
         if key == "wired.account.color" ||
-            key.hasPrefix("wired.account.chat.create_") ||
-            key == "wired.account.chat.set_topic" ||
             key == "wired.account.user.cannot_set_nick" ||
             key == "wired.account.user.get_info" {
             return .basic
+        }
+
+        // All wired.account.chat.* permissions live in the Chat category, except
+        // kick_users which is a moderation action grouped with users below.
+        if key.hasPrefix("wired.account.chat.") && key != "wired.account.chat.kick_users" {
+            return .chat
         }
 
         if key.hasPrefix("wired.account.message.")

--- a/Wired 3/Models/Chat.swift
+++ b/Wired 3/Models/Chat.swift
@@ -27,6 +27,11 @@ final class Chat: Identifiable {
     var hasMoreHistory: Bool = false
 
     var unreadMessagesCount: Int = 0
+    var unreadReactionCount: Int = 0
+
+    var totalUnreadCount: Int {
+        unreadMessagesCount + unreadReactionCount
+    }
 
     init(id: UInt32, name: String, isPrivate: Bool = false) {
         self.id = id
@@ -36,6 +41,18 @@ final class Chat: Identifiable {
 }
 
 extension ChatEvent {
+    var reactionNotificationSubject: String {
+        let trimmedText = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmedText.isEmpty {
+            return "a message from \(user.nick)"
+        }
+
+        let preview = trimmedText.count > 80
+            ? "\(trimmedText.prefix(77))..."
+            : trimmedText
+        return "\"\(preview)\""
+    }
+
     func matchesSearch(_ rawQuery: String) -> Bool {
         let query = rawQuery.trimmedChatSearchQuery
         guard !query.isEmpty else { return true }

--- a/Wired 3/Models/ChatEvent.swift
+++ b/Wired 3/Models/ChatEvent.swift
@@ -32,6 +32,25 @@ public enum ChatEventType {
     }
 }
 
+/// Lightweight summary of a single emoji reaction on a chat message.
+/// Mirror of `BoardReactionSummary`, kept separate so the two surfaces
+/// can evolve independently.
+struct ChatReactionSummary: Identifiable, Equatable {
+    let emoji: String
+    let count: Int
+    let isOwn: Bool
+    var nicks: [String]
+
+    var id: String { emoji }
+
+    init(emoji: String, count: Int, isOwn: Bool, nicks: [String] = []) {
+        self.emoji = emoji
+        self.count = count
+        self.isOwn = isOwn
+        self.nicks = nicks
+    }
+}
+
 @Observable
 @MainActor
 final class ChatEvent: Identifiable {
@@ -43,6 +62,19 @@ final class ChatEvent: Identifiable {
     var type: ChatEventType
     var date = Date()
     var attachments: [ChatAttachmentDescriptor]
+
+    /// Server-stamped message id (Wired 3.2). Nil on pre-3.2 servers and on
+    /// archived messages from before the field was introduced. Used to
+    /// correlate reactions back to the message.
+    var serverMessageID: String?
+
+    /// Reaction summaries for this message. Only populated on 3.2 servers
+    /// after a `wired.chat.get_reactions` round-trip or an incoming
+    /// `wired.chat.reaction_added`/`reaction_removed` broadcast.
+    var reactions: [ChatReactionSummary] = []
+    var reactionsLoaded: Bool = false
+    /// Emojis that arrived from other users and haven't been animated yet.
+    var newReactionEmojis: Set<String> = []
 
     /// When non-nil, overrides `user.id == runtime.userID` for display alignment.
     /// Set for archived messages where the original userID may differ from the current session.

--- a/Wired 3/de.lproj/Localizable.strings
+++ b/Wired 3/de.lproj/Localizable.strings
@@ -601,6 +601,7 @@
 "wired.account.chat.create_chats" = "Chats erstellen";
 "wired.account.chat.create_public_chats" = "Öffentliche Chats erstellen";
 "wired.account.chat.delete_public_chats" = "Öffentliche Chats löschen";
+"wired.account.chat.add_reactions" = "Reaktionen hinzufügen";
 
 /* ── User privileges (additions) ── */
 "wired.account.user.cannot_set_nick" = "Kann Spitzname nicht ändern";

--- a/Wired 3/en.lproj/Localizable.strings
+++ b/Wired 3/en.lproj/Localizable.strings
@@ -604,6 +604,7 @@
 "wired.account.chat.create_chats" = "Create Chats";
 "wired.account.chat.create_public_chats" = "Create Public Chats";
 "wired.account.chat.delete_public_chats" = "Delete Public Chats";
+"wired.account.chat.add_reactions" = "Add Reactions";
 
 /* ── User privileges (additions) ── */
 "wired.account.user.cannot_set_nick" = "Cannot Set Nick";

--- a/Wired 3/fr.lproj/Localizable.strings
+++ b/Wired 3/fr.lproj/Localizable.strings
@@ -602,6 +602,7 @@
 "wired.account.chat.create_chats" = "Créer des chats";
 "wired.account.chat.create_public_chats" = "Créer des chats publics";
 "wired.account.chat.delete_public_chats" = "Supprimer des chats publics";
+"wired.account.chat.add_reactions" = "Ajouter des réactions";
 
 /* ── User privileges (additions) ── */
 "wired.account.user.cannot_set_nick" = "Ne peut pas changer de pseudo";

--- a/Wired-macOS.xcodeproj/project.pbxproj
+++ b/Wired-macOS.xcodeproj/project.pbxproj
@@ -21,12 +21,14 @@
 		4C0C2DFC2EF558DF00213277 /* TabsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C0C2DFB2EF558DF00213277 /* TabsView.swift */; };
 		4C0C2E002EF5649C00213277 /* ConnectionRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C0C2DFF2EF5649C00213277 /* ConnectionRowView.swift */; };
 		4C0C2E072EF5C84000213277 /* ConnectionRuntime.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C0C2E062EF5C83E00213277 /* ConnectionRuntime.swift */; };
+		4CCR03422F900002000C0001 /* ConnectionRuntime+ChatReactions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CCR03432F900002000C0001 /* ConnectionRuntime+ChatReactions.swift */; };
 		4C0C2E092EF7F68F00213277 /* ChatsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C0C2E082EF7F68F00213277 /* ChatsView.swift */; };
 		4C0C2E132EF9E19700213277 /* Image+Data.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C0C2E122EF9E19700213277 /* Image+Data.swift */; };
 		4C0C2E152EFC833D00213277 /* ChatView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C0C2E142EFC833D00213277 /* ChatView.swift */; };
 		4C0C2E182EFD455300213277 /* MessageBubble.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C0C2E172EFD455300213277 /* MessageBubble.swift */; };
 		4C0C2E1C2EFD7C4E00213277 /* ChatTopicView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C0C2E1B2EFD7C4E00213277 /* ChatTopicView.swift */; };
 		4C0C2E1E2EFD7C6300213277 /* ChatSayMessageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C0C2E1D2EFD7C6300213277 /* ChatSayMessageView.swift */; };
+		4CCR03402F900001000C0001 /* ChatReactionBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CCR03412F900001000C0001 /* ChatReactionBarView.swift */; };
 		4C0C2E202EFD7DD200213277 /* ChatEventView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C0C2E1F2EFD7DD200213277 /* ChatEventView.swift */; };
 		4C0C2E292EFDB90A00213277 /* ConnectionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C0C2E282EFDB90A00213277 /* ConnectionState.swift */; };
 		4C0C2E2B2EFDB92200213277 /* Chat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C0C2E2A2EFDB92100213277 /* Chat.swift */; };
@@ -172,12 +174,14 @@
 		4C0C2DFB2EF558DF00213277 /* TabsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabsView.swift; sourceTree = "<group>"; };
 		4C0C2DFF2EF5649C00213277 /* ConnectionRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionRowView.swift; sourceTree = "<group>"; };
 		4C0C2E062EF5C83E00213277 /* ConnectionRuntime.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionRuntime.swift; sourceTree = "<group>"; };
+		4CCR03432F900002000C0001 /* ConnectionRuntime+ChatReactions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ConnectionRuntime+ChatReactions.swift"; sourceTree = "<group>"; };
 		4C0C2E082EF7F68F00213277 /* ChatsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatsView.swift; sourceTree = "<group>"; };
 		4C0C2E122EF9E19700213277 /* Image+Data.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Image+Data.swift"; sourceTree = "<group>"; };
 		4C0C2E142EFC833D00213277 /* ChatView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatView.swift; sourceTree = "<group>"; };
 		4C0C2E172EFD455300213277 /* MessageBubble.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageBubble.swift; sourceTree = "<group>"; };
 		4C0C2E1B2EFD7C4E00213277 /* ChatTopicView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatTopicView.swift; sourceTree = "<group>"; };
 		4C0C2E1D2EFD7C6300213277 /* ChatSayMessageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatSayMessageView.swift; sourceTree = "<group>"; };
+		4CCR03412F900001000C0001 /* ChatReactionBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatReactionBarView.swift; sourceTree = "<group>"; };
 		4C0C2E1F2EFD7DD200213277 /* ChatEventView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatEventView.swift; sourceTree = "<group>"; };
 		4C0C2E282EFDB90A00213277 /* ConnectionState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionState.swift; sourceTree = "<group>"; };
 		4C0C2E2A2EFDB92100213277 /* Chat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Chat.swift; sourceTree = "<group>"; };
@@ -368,6 +372,7 @@
 				4C0C2DF42EF485A300213277 /* DelegateProxy.swift */,
 				4C0C2DF62EF4872600213277 /* ConnectionController.swift */,
 				4C0C2E062EF5C83E00213277 /* ConnectionRuntime.swift */,
+				4CCR03432F900002000C0001 /* ConnectionRuntime+ChatReactions.swift */,
 			);
 			path = Connection;
 			sourceTree = "<group>";
@@ -401,6 +406,7 @@
 				4C0C2E3B2F0042FA00213277 /* ChatMessagesView.swift */,
 				AB1000043000000100213277 /* ChatAttachmentViews.swift */,
 				4C0C2E1D2EFD7C6300213277 /* ChatSayMessageView.swift */,
+				4CCR03412F900001000C0001 /* ChatReactionBarView.swift */,
 				4C0C2E322EFDBA9E00213277 /* ChatMeMessageView.swift */,
 				4C0C2E1F2EFD7DD200213277 /* ChatEventView.swift */,
 				4C0C2E172EFD455300213277 /* MessageBubble.swift */,
@@ -941,8 +947,10 @@
 				4C8D11042F30000100213277 /* StoredBroadcastMessage.swift in Sources */,
 				4C8D11052F30000100213277 /* StoredMessageSelection.swift in Sources */,
 				4C0C2E072EF5C84000213277 /* ConnectionRuntime.swift in Sources */,
+				4CCR03422F900002000C0001 /* ConnectionRuntime+ChatReactions.swift in Sources */,
 				AB1000033000000100213277 /* ChatAttachmentViews.swift in Sources */,
 				4C0C2E1E2EFD7C6300213277 /* ChatSayMessageView.swift in Sources */,
+				4CCR03402F900001000C0001 /* ChatReactionBarView.swift in Sources */,
 				4C8A826B2F5ED07200C271A8 /* MessageConversationDetailView.swift in Sources */,
 				4C0C2E482F07F6EF00213277 /* View.swift in Sources */,
 				4C0C2E332EFDBA9E00213277 /* ChatMeMessageView.swift in Sources */,


### PR DESCRIPTION
## Summary

- Re-applies the chat-reactions macOS work from #41 after reverting the merged PR and follow-up fix from `main`.
- Adds a reaction picker for public-chat messages; the latest interaction model uses long-press / double-click instead of hover.
- Each `ChatEvent` carries the server-stamped `wired.chat.message.id` and a `[ChatReactionSummary]`; reactions are loaded lazily via `wired.chat.get_reactions` the first time a message becomes visible.
- The reactions row is gated on `runtime.connection?.socket.peerKnows(messageNamed: "wired.chat.add_reaction")` — on a 3.1 server the UI is invisible (no toasts, no surprise affordances).
- `ConnectionController` forwards `reaction_added` / `reaction_removed` broadcasts into the runtime, where `applyChatReactionBroadcast` updates the in-memory event in place.

Closes #40. Server-side: [WiredSwift#93](https://github.com/nark/WiredSwift/pull/93).

Original merged PR: #41. Revert commits: `fe6b251`, `b5d7b03`. Re-apply commits: `98aa2a0`, `2180da2`.

## Test plan

- [x] `xcodebuild -scheme "Wired 3"` was green in the original PR.
- [ ] Connect to a 3.2 server (WiredSwift#93), join the public chat, long-press / double-click a message → picker appears; pick a reaction → chip animates in. Confirm with a second client.
- [ ] Connect to a 3.1 server: no picker, no badges, no errors.
- [ ] React on a message that's been evicted from the server's ring buffer → quiet info hint, no error toast.