### PR TITLE
refactor(syncd): register wiredsyncd via SMAppService instead of manual launchctl

### DIFF
--- a/Wired 3/Features/Files/FileSyncSupport.swift
+++ b/Wired 3/Features/Files/FileSyncSupport.swift
@@ -628,9 +628,16 @@ enum WiredSyncDaemonIPC {
 
     /// Checks the running daemon version and, if outdated, asks it to shut down so
     /// launchd's KeepAlive restarts it with the updated binary from the app bundle.
-    /// No binary copying or plist re-installation is needed.
+    /// Also migrates from the legacy launchctl-based setup to SMAppService if needed.
     static func ensureDaemonIsCurrentVersion() {
         Task.detached(priority: .background) {
+            // Proactive migration: if the old manually-managed LaunchAgent plist still
+            // exists, the app was updated from a pre-SMAppService build. Migrate now
+            // regardless of whether the IPC call below succeeds.
+            let fm = FileManager.default
+            let needsMigration = fm.fileExists(atPath: legacyLaunchAgentPath)
+                              || fm.fileExists(atPath: legacyDaemonInstallPath)
+
             do {
                 let result = try performRequest(
                     ["jsonrpc": "2.0", "id": UUID().uuidString, "method": "status"],
@@ -638,15 +645,19 @@ enum WiredSyncDaemonIPC {
                 )
                 let data = result["result"] as? [String: Any]
                 let runningVersion = data?["version"] as? String ?? ""
-                guard runningVersion != expectedDaemonVersion else { return }
-                print("[WiredSyncUI] daemon.version_mismatch running=\(runningVersion) expected=\(expectedDaemonVersion) – restarting via shutdown")
-                _ = try? performRequest(
-                    ["jsonrpc": "2.0", "id": UUID().uuidString, "method": "shutdown"],
-                    timeoutSeconds: 3
-                )
-                // launchd's KeepAlive: true restarts the daemon with the new binary.
+                if runningVersion != expectedDaemonVersion || needsMigration {
+                    print("[WiredSyncUI] daemon.update_or_migrate running=\(runningVersion) expected=\(expectedDaemonVersion) needsMigration=\(needsMigration)")
+                    _ = try? performRequest(
+                        ["jsonrpc": "2.0", "id": UUID().uuidString, "method": "shutdown"],
+                        timeoutSeconds: 3
+                    )
+                    // Give the old process a moment to exit before SMAppService takes over.
+                    try? await Task.sleep(nanoseconds: 500_000_000)
+                    try installAndStartLaunchAgent()
+                }
             } catch {
-                // Daemon unreachable — SMAppService manages lifecycle automatically.
+                // Daemon unreachable — install/register via SMAppService.
+                try? installAndStartLaunchAgent()
             }
         }
     }

--- a/Wired 3/Features/Files/FileSyncSupport.swift
+++ b/Wired 3/Features/Files/FileSyncSupport.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ServiceManagement
 import WiredSwift
 #if os(macOS)
 import Darwin
@@ -74,20 +75,11 @@ enum WiredSyncDaemonIPC {
     static let socketPath = (runPath as NSString).appendingPathComponent("wiredsyncd.sock")
     static let configPath = (baseSupportPath as NSString).appendingPathComponent("config.json")
     static let statePath = (baseSupportPath as NSString).appendingPathComponent("state.sqlite")
-    static let daemonInstallPath = (baseSupportPath as NSString).appendingPathComponent("daemon")
-    static let daemonResourcesPath = (daemonInstallPath as NSString).appendingPathComponent("Resources")
-    static let installedDaemonPath = (daemonInstallPath as NSString).appendingPathComponent("wiredsyncd")
     static let launchAgentLabel = "fr.read-write.wiredsyncd"
 
-    private static var wiredSyncApplicationVersion: String? {
-        WiredApplicationInfo.current().version
-    }
-
-    private static var wiredSyncApplicationBuild: String? {
-        WiredApplicationInfo.current().build
-    }
-
-    static let launchAgentPath = (FileManager.default.homeDirectoryForCurrentUser.path as NSString)
+    // Legacy path kept for one-time migration of manually-installed daemon artifacts.
+    private static let legacyDaemonInstallPath = (baseSupportPath as NSString).appendingPathComponent("daemon")
+    private static let legacyLaunchAgentPath = (FileManager.default.homeDirectoryForCurrentUser.path as NSString)
         .appendingPathComponent("Library/LaunchAgents/\(launchAgentLabel).plist")
 
     static let expectedDaemonVersion = "29"
@@ -480,136 +472,71 @@ enum WiredSyncDaemonIPC {
         return fd
     }
 
+    // MARK: - Agent Registration
+
+    /// Registers wiredsyncd as a Login Item via SMAppService (macOS 13+).
+    /// The daemon binary lives in the app bundle at Contents/MacOS/wiredsyncd;
+    /// no binary copying is needed. On first call after an update, any legacy
+    /// manually-managed LaunchAgent artifacts are removed automatically.
     private static func installAndStartLaunchAgent() throws {
         let fm = FileManager.default
-        let launchAgentsDir = (FileManager.default.homeDirectoryForCurrentUser.path as NSString).appendingPathComponent("Library/LaunchAgents")
-        let logDir = (FileManager.default.homeDirectoryForCurrentUser.path as NSString).appendingPathComponent("Library/Logs/WiredSync")
-        try fm.createDirectory(atPath: launchAgentsDir, withIntermediateDirectories: true)
+        let logDir = (fm.homeDirectoryForCurrentUser.path as NSString)
+            .appendingPathComponent("Library/Logs/WiredSync")
         try fm.createDirectory(atPath: logDir, withIntermediateDirectories: true)
         try fm.createDirectory(atPath: runPath, withIntermediateDirectories: true)
-
-        let daemonPath = try installDaemonArtifacts()
         try? fm.removeItem(atPath: socketPath)
-        print("[WiredSyncUI] launchd.install daemon=\(daemonPath) resource_root=\(daemonResourcesPath)")
 
-        var environmentVariables: [String: String] = [
-            "WIRED_SYNCD_RESOURCE_ROOT": daemonResourcesPath,
-            "WIRED_APPLICATION_NAME": "wiredsyncd"
-        ]
-        if let version = wiredSyncApplicationVersion {
-            environmentVariables["WIRED_APPLICATION_VERSION"] = version
+        migrateRemoveLegacyLaunchAgent()
+
+        let service = SMAppService.agent(plistName: "\(launchAgentLabel).plist")
+        switch service.status {
+        case .enabled:
+            break
+        case .requiresApproval:
+            throw NSError(domain: "wiredsyncd.ipc", code: 12, userInfo: [
+                NSLocalizedDescriptionKey: "Open System Settings → General → Login Items and enable Wired Sync to allow background syncing."
+            ])
+        case .notRegistered, .notFound:
+            do {
+                try service.register()
+            } catch {
+                if service.status == .requiresApproval {
+                    throw NSError(domain: "wiredsyncd.ipc", code: 12, userInfo: [
+                        NSLocalizedDescriptionKey: "Open System Settings → General → Login Items and enable Wired Sync to allow background syncing."
+                    ])
+                }
+                throw NSError(domain: "wiredsyncd.ipc", code: 9, userInfo: [
+                    NSLocalizedDescriptionKey: "Failed to register wiredsyncd: \(error.localizedDescription)"
+                ])
+            }
+            if service.status == .requiresApproval {
+                throw NSError(domain: "wiredsyncd.ipc", code: 12, userInfo: [
+                    NSLocalizedDescriptionKey: "Open System Settings → General → Login Items and enable Wired Sync to allow background syncing."
+                ])
+            }
+        @unknown default:
+            break
         }
-        if let build = wiredSyncApplicationBuild {
-            environmentVariables["WIRED_APPLICATION_BUILD"] = build
-        }
 
-        let plist: [String: Any] = [
-            "Label": launchAgentLabel,
-            "ProgramArguments": [daemonPath],
-            "RunAtLoad": true,
-            "KeepAlive": true,
-            "WorkingDirectory": daemonInstallPath,
-            "EnvironmentVariables": environmentVariables,
-            "StandardOutPath": (logDir as NSString).appendingPathComponent("wiredsyncd.out.log"),
-            "StandardErrorPath": (logDir as NSString).appendingPathComponent("wiredsyncd.err.log"),
-            "ProcessType": "Background",
-            "ThrottleInterval": 1
-        ]
-
-        let data = try PropertyListSerialization.data(fromPropertyList: plist, format: .xml, options: 0)
-        try data.write(to: URL(fileURLWithPath: launchAgentPath), options: .atomic)
-
-        let domain = "gui/\(getuid())"
-        _ = try runLaunchctl(arguments: ["bootout", "\(domain)/\(launchAgentLabel)"], allowFailure: true)
-        _ = try runLaunchctl(arguments: ["bootout", domain, launchAgentPath], allowFailure: true)
-        _ = try runLaunchctl(arguments: ["enable", "\(domain)/\(launchAgentLabel)"], allowFailure: true)
-        _ = try runLaunchctl(arguments: ["bootstrap", domain, launchAgentPath], allowFailure: false)
         try waitForDaemonReady()
     }
 
-    private static func installDaemonArtifacts() throws -> String {
+    /// Removes the old manually-managed LaunchAgent plist and copied binary if they exist.
+    /// Called once on the first launch after migrating to SMAppService.
+    private static func migrateRemoveLegacyLaunchAgent() {
         let fm = FileManager.default
-        try fm.createDirectory(atPath: daemonInstallPath, withIntermediateDirectories: true)
-        try fm.createDirectory(atPath: daemonResourcesPath, withIntermediateDirectories: true)
-
-        let sourceBinaryPath = try resolveBundledDaemonExecutablePath()
-        try installFile(from: sourceBinaryPath, to: installedDaemonPath, executable: true)
-
-        if let resourcePath = resolveBundledDaemonResourcePath() {
-            let installedResourcePath = (daemonResourcesPath as NSString).appendingPathComponent("wired.xml")
-            try installFile(from: resourcePath, to: installedResourcePath, executable: false)
-        }
-
-        return installedDaemonPath
-    }
-
-    private static func installFile(from sourcePath: String, to destinationPath: String, executable: Bool) throws {
-        let fm = FileManager.default
-        let tempPath = destinationPath + ".tmp"
-        try? fm.removeItem(atPath: tempPath)
-        if fm.fileExists(atPath: destinationPath) {
-            try fm.removeItem(atPath: destinationPath)
-        }
-        try fm.copyItem(atPath: sourcePath, toPath: tempPath)
-        if executable {
-            try fm.setAttributes([.posixPermissions: 0o755], ofItemAtPath: tempPath)
-        } else {
-            try fm.setAttributes([.posixPermissions: 0o644], ofItemAtPath: tempPath)
-        }
-        try fm.moveItem(atPath: tempPath, toPath: destinationPath)
-    }
-
-    private static func resolveBundledDaemonExecutablePath() throws -> String {
-        let fm = FileManager.default
-        let env = ProcessInfo.processInfo.environment
-
-        var candidates: [String] = []
-        if let fromEnv = env["WIRED_SYNCD_PATH"], !fromEnv.isEmpty {
-            candidates.append(fromEnv)
-        }
-        if let aux = Bundle.main.url(forAuxiliaryExecutable: "wiredsyncd")?.path {
-            candidates.append(aux)
-        }
-        candidates.append((Bundle.main.bundlePath as NSString).appendingPathComponent("Contents/MacOS/wiredsyncd"))
-        candidates.append((FileManager.default.currentDirectoryPath as NSString).appendingPathComponent("wiredsyncd/.build/debug/wiredsyncd"))
-        candidates.append((FileManager.default.currentDirectoryPath as NSString).appendingPathComponent("wiredsyncd/.build/release/wiredsyncd"))
-        candidates.append((NSHomeDirectory() as NSString).appendingPathComponent(".local/bin/wiredsyncd"))
-        candidates.append("/opt/homebrew/bin/wiredsyncd")
-        candidates.append("/usr/local/bin/wiredsyncd")
-
-        for candidate in candidates {
-            if fm.fileExists(atPath: candidate), fm.isExecutableFile(atPath: candidate) {
-                return candidate
-            }
-        }
-
-        throw NSError(
-            domain: "wiredsyncd.ipc",
-            code: 8,
-            userInfo: [NSLocalizedDescriptionKey: "Unable to locate wiredsyncd executable. Set WIRED_SYNCD_PATH or install wiredsyncd in PATH."]
-        )
-    }
-
-    private static func resolveBundledDaemonResourcePath() -> String? {
-        let fm = FileManager.default
-        let candidates: [String?] = [
-            WiredProtocolSpec.bundledSpecURL()?.path,
-            (Bundle.main.bundlePath as NSString).appendingPathComponent("Contents/Resources/wired.xml"),
-            (FileManager.default.currentDirectoryPath as NSString).appendingPathComponent("WiredSwift/Sources/WiredSwift/Resources/wired.xml")
-        ]
-
-        for candidate in candidates.compactMap({ $0 }) {
-            if fm.fileExists(atPath: candidate) {
-                return candidate
-            }
-        }
-
-        return nil
-    }
-
-    @discardableResult
-    private static func runLaunchctl(arguments: [String], allowFailure: Bool) throws -> String {
-        try runExecutable(path: "/bin/launchctl", arguments: arguments, allowFailure: allowFailure)
+        guard fm.fileExists(atPath: legacyLaunchAgentPath) ||
+              fm.fileExists(atPath: legacyDaemonInstallPath) else { return }
+        let domain = "gui/\(getuid())"
+        _ = try? runExecutable(path: "/bin/launchctl",
+                               arguments: ["bootout", "\(domain)/\(launchAgentLabel)"],
+                               allowFailure: true)
+        _ = try? runExecutable(path: "/bin/launchctl",
+                               arguments: ["bootout", domain, legacyLaunchAgentPath],
+                               allowFailure: true)
+        try? fm.removeItem(atPath: legacyLaunchAgentPath)
+        try? fm.removeItem(atPath: legacyDaemonInstallPath)
+        print("[WiredSyncUI] migration.removed_legacy_agent")
     }
 
     @discardableResult
@@ -699,6 +626,9 @@ enum WiredSyncDaemonIPC {
         )
     }
 
+    /// Checks the running daemon version and, if outdated, asks it to shut down so
+    /// launchd's KeepAlive restarts it with the updated binary from the app bundle.
+    /// No binary copying or plist re-installation is needed.
     static func ensureDaemonIsCurrentVersion() {
         Task.detached(priority: .background) {
             do {
@@ -709,20 +639,14 @@ enum WiredSyncDaemonIPC {
                 let data = result["result"] as? [String: Any]
                 let runningVersion = data?["version"] as? String ?? ""
                 guard runningVersion != expectedDaemonVersion else { return }
-                print("[WiredSyncUI] daemon.version_mismatch running=\(runningVersion) expected=\(expectedDaemonVersion) – reinstalling")
+                print("[WiredSyncUI] daemon.version_mismatch running=\(runningVersion) expected=\(expectedDaemonVersion) – restarting via shutdown")
+                _ = try? performRequest(
+                    ["jsonrpc": "2.0", "id": UUID().uuidString, "method": "shutdown"],
+                    timeoutSeconds: 3
+                )
+                // launchd's KeepAlive: true restarts the daemon with the new binary.
             } catch {
-                let fm = FileManager.default
-                guard fm.fileExists(atPath: launchAgentPath) || fm.fileExists(atPath: installedDaemonPath) else {
-                    return
-                }
-                print("[WiredSyncUI] daemon.status_unavailable expected=\(expectedDaemonVersion) error=\(error.localizedDescription) – reinstalling")
-            }
-
-            do {
-                try installAndStartLaunchAgent()
-                print("[WiredSyncUI] daemon.version_update_ok version=\(expectedDaemonVersion)")
-            } catch {
-                print("[WiredSyncUI] daemon.version_update_failed error=\(error.localizedDescription)")
+                // Daemon unreachable — SMAppService manages lifecycle automatically.
             }
         }
     }

--- a/Wired 3/fr.read-write.wiredsyncd.plist
+++ b/Wired 3/fr.read-write.wiredsyncd.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>fr.read-write.wiredsyncd</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>$(AppBundlePath)/Contents/MacOS/wiredsyncd</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+    <key>ProcessType</key>
+    <string>Background</string>
+    <key>ThrottleInterval</key>
+    <integer>1</integer>
+    <key>StandardOutPath</key>
+    <string>~/Library/Logs/WiredSync/wiredsyncd.out.log</string>
+    <key>StandardErrorPath</key>
+    <string>~/Library/Logs/WiredSync/wiredsyncd.err.log</string>
+</dict>
+</plist>

--- a/Wired-macOS.xcodeproj/project.pbxproj
+++ b/Wired-macOS.xcodeproj/project.pbxproj
@@ -21,14 +21,12 @@
 		4C0C2DFC2EF558DF00213277 /* TabsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C0C2DFB2EF558DF00213277 /* TabsView.swift */; };
 		4C0C2E002EF5649C00213277 /* ConnectionRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C0C2DFF2EF5649C00213277 /* ConnectionRowView.swift */; };
 		4C0C2E072EF5C84000213277 /* ConnectionRuntime.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C0C2E062EF5C83E00213277 /* ConnectionRuntime.swift */; };
-		4CCR03422F900002000C0001 /* ConnectionRuntime+ChatReactions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CCR03432F900002000C0001 /* ConnectionRuntime+ChatReactions.swift */; };
 		4C0C2E092EF7F68F00213277 /* ChatsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C0C2E082EF7F68F00213277 /* ChatsView.swift */; };
 		4C0C2E132EF9E19700213277 /* Image+Data.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C0C2E122EF9E19700213277 /* Image+Data.swift */; };
 		4C0C2E152EFC833D00213277 /* ChatView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C0C2E142EFC833D00213277 /* ChatView.swift */; };
 		4C0C2E182EFD455300213277 /* MessageBubble.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C0C2E172EFD455300213277 /* MessageBubble.swift */; };
 		4C0C2E1C2EFD7C4E00213277 /* ChatTopicView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C0C2E1B2EFD7C4E00213277 /* ChatTopicView.swift */; };
 		4C0C2E1E2EFD7C6300213277 /* ChatSayMessageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C0C2E1D2EFD7C6300213277 /* ChatSayMessageView.swift */; };
-		4CCR03402F900001000C0001 /* ChatReactionBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CCR03412F900001000C0001 /* ChatReactionBarView.swift */; };
 		4C0C2E202EFD7DD200213277 /* ChatEventView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C0C2E1F2EFD7DD200213277 /* ChatEventView.swift */; };
 		4C0C2E292EFDB90A00213277 /* ConnectionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C0C2E282EFDB90A00213277 /* ConnectionState.swift */; };
 		4C0C2E2B2EFDB92200213277 /* Chat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C0C2E2A2EFDB92100213277 /* Chat.swift */; };
@@ -108,6 +106,8 @@
 		4CBF0A272F8CCBB2004196FD /* FilesBreadcrumbView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CBF0A262F8CCBA5004196FD /* FilesBreadcrumbView.swift */; };
 		4CBF0A292F8CD448004196FD /* FilesServerInfos.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CBF0A282F8CD448004196FD /* FilesServerInfos.swift */; };
 		4CBF0A2B2F8CE999004196FD /* Executable.icns in Resources */ = {isa = PBXBuildFile; fileRef = 4CBF0A2A2F8CE999004196FD /* Executable.icns */; };
+		4CCR03402F900001000C0001 /* ChatReactionBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CCR03412F900001000C0001 /* ChatReactionBarView.swift */; };
+		4CCR03422F900002000C0001 /* ConnectionRuntime+ChatReactions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CCR03432F900002000C0001 /* ConnectionRuntime+ChatReactions.swift */; };
 		4CDBA0012F80000100213277 /* RelativeDateText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CDBA0022F80000100213277 /* RelativeDateText.swift */; };
 		4CF01A922F20000100213277 /* FileInfoSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CF01A912F20000100213277 /* FileInfoSheet.swift */; };
 		4CF01A942F200A1100213277 /* UploadsBadge.icns in Resources */ = {isa = PBXBuildFile; fileRef = 4CF01A962F200A1100213277 /* UploadsBadge.icns */; };
@@ -139,6 +139,8 @@
 		CC100009FA00000100213277 /* ChatHistoryDayList.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC100004FA00000100213277 /* ChatHistoryDayList.swift */; };
 		CC10000AFA00000100213277 /* ChatHistoryMessagesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC100005FA00000100213277 /* ChatHistoryMessagesView.swift */; };
 		CC10000BFA00000100213277 /* ArchiveMessageBubbleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC100006FA00000100213277 /* ArchiveMessageBubbleView.swift */; };
+		F6C75EF02FB0FABC004582DE /* fr.read-write.wiredsyncd.plist in Resources */ = {isa = PBXBuildFile; fileRef = F6C75EEF2FB0FABC004582DE /* fr.read-write.wiredsyncd.plist */; };
+		F6C75EF12FB0FAED004582DE /* fr.read-write.wiredsyncd.plist in CopyFiles */ = {isa = PBXBuildFile; fileRef = F6C75EEF2FB0FABC004582DE /* fr.read-write.wiredsyncd.plist */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -158,6 +160,19 @@
 		};
 /* End PBXContainerItemProxy section */
 
+/* Begin PBXCopyFilesBuildPhase section */
+		F6C75EEE2FB0F9A3004582DE /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = Contents/Library/LaunchAgents;
+			dstSubfolderSpec = 1;
+			files = (
+				F6C75EF12FB0FAED004582DE /* fr.read-write.wiredsyncd.plist in CopyFiles */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
 /* Begin PBXFileReference section */
 		4C0C2DB42EF436FE00213277 /* Wired Client.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Wired Client.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		4C0C2DC32EF4370000213277 /* Wired 3Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Wired 3Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -174,14 +189,12 @@
 		4C0C2DFB2EF558DF00213277 /* TabsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabsView.swift; sourceTree = "<group>"; };
 		4C0C2DFF2EF5649C00213277 /* ConnectionRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionRowView.swift; sourceTree = "<group>"; };
 		4C0C2E062EF5C83E00213277 /* ConnectionRuntime.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionRuntime.swift; sourceTree = "<group>"; };
-		4CCR03432F900002000C0001 /* ConnectionRuntime+ChatReactions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ConnectionRuntime+ChatReactions.swift"; sourceTree = "<group>"; };
 		4C0C2E082EF7F68F00213277 /* ChatsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatsView.swift; sourceTree = "<group>"; };
 		4C0C2E122EF9E19700213277 /* Image+Data.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Image+Data.swift"; sourceTree = "<group>"; };
 		4C0C2E142EFC833D00213277 /* ChatView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatView.swift; sourceTree = "<group>"; };
 		4C0C2E172EFD455300213277 /* MessageBubble.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageBubble.swift; sourceTree = "<group>"; };
 		4C0C2E1B2EFD7C4E00213277 /* ChatTopicView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatTopicView.swift; sourceTree = "<group>"; };
 		4C0C2E1D2EFD7C6300213277 /* ChatSayMessageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatSayMessageView.swift; sourceTree = "<group>"; };
-		4CCR03412F900001000C0001 /* ChatReactionBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatReactionBarView.swift; sourceTree = "<group>"; };
 		4C0C2E1F2EFD7DD200213277 /* ChatEventView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatEventView.swift; sourceTree = "<group>"; };
 		4C0C2E282EFDB90A00213277 /* ConnectionState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionState.swift; sourceTree = "<group>"; };
 		4C0C2E2A2EFDB92100213277 /* Chat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Chat.swift; sourceTree = "<group>"; };
@@ -263,6 +276,8 @@
 		4CBF0A262F8CCBA5004196FD /* FilesBreadcrumbView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilesBreadcrumbView.swift; sourceTree = "<group>"; };
 		4CBF0A282F8CD448004196FD /* FilesServerInfos.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilesServerInfos.swift; sourceTree = "<group>"; };
 		4CBF0A2A2F8CE999004196FD /* Executable.icns */ = {isa = PBXFileReference; lastKnownFileType = image.icns; path = Executable.icns; sourceTree = "<group>"; };
+		4CCR03412F900001000C0001 /* ChatReactionBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatReactionBarView.swift; sourceTree = "<group>"; };
+		4CCR03432F900002000C0001 /* ConnectionRuntime+ChatReactions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ConnectionRuntime+ChatReactions.swift"; sourceTree = "<group>"; };
 		4CDBA0022F80000100213277 /* RelativeDateText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelativeDateText.swift; sourceTree = "<group>"; };
 		4CF01A912F20000100213277 /* FileInfoSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileInfoSheet.swift; sourceTree = "<group>"; };
 		4CF01A962F200A1100213277 /* UploadsBadge.icns */ = {isa = PBXFileReference; lastKnownFileType = image.icns; path = UploadsBadge.icns; sourceTree = "<group>"; };
@@ -297,6 +312,7 @@
 		CC100005FA00000100213277 /* ChatHistoryMessagesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatHistoryMessagesView.swift; sourceTree = "<group>"; };
 		CC100006FA00000100213277 /* ArchiveMessageBubbleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveMessageBubbleView.swift; sourceTree = "<group>"; };
 		F69436752FA4A557005137D5 /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/Localizable.strings; sourceTree = "<group>"; };
+		F6C75EEF2FB0FABC004582DE /* fr.read-write.wiredsyncd.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "fr.read-write.wiredsyncd.plist"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
@@ -349,6 +365,7 @@
 				4C0C2E232EFDB8BF00213277 /* Additions */,
 				4C0C2DE32EF437DE00213277 /* Wired_3.entitlements */,
 				D313D2D267BF39158BC11A99 /* Localizable.strings */,
+				F6C75EEF2FB0FABC004582DE /* fr.read-write.wiredsyncd.plist */,
 			);
 			path = "Wired 3";
 			sourceTree = "<group>";
@@ -671,6 +688,7 @@
 				4C0C2DB12EF436FE00213277 /* Frameworks */,
 				4C90D0102FA1000100213277 /* Embed wiredsyncd */,
 				4C0C2DB22EF436FE00213277 /* Resources */,
+				F6C75EEE2FB0F9A3004582DE /* CopyFiles */,
 			);
 			buildRules = (
 			);
@@ -798,6 +816,7 @@
 				4CF01A942F200A1100213277 /* UploadsBadge.icns in Resources */,
 				4CF01A952F200A1100213277 /* DropBoxBadge.icns in Resources */,
 				4C90D0012FA1000100213277 /* SyncBadge.icns in Resources */,
+				F6C75EF02FB0FABC004582DE /* fr.read-write.wiredsyncd.plist in Resources */,
 				09384B2E75CDFD4041BA5425 /* Localizable.strings in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
## Summary

- Replaces the dynamic plist generation + `launchctl bootstrap/enable` approach with `SMAppService.agent()`, the modern macOS 13+ API for background agents
- wiredsyncd now runs **independently of the app** — launchd keeps it alive even when Wired 3 is closed, at login, and after system reboots
- wiredsyncd now appears in **System Settings → General → Login Items** so users can see and control it
- The LaunchAgent plist is bundled at `Contents/Library/LaunchAgents/fr.read-write.wiredsyncd.plist` — no more writing a plist to disk at runtime
- The daemon binary runs directly from `Contents/MacOS/wiredsyncd` — no more copying to `~/Library/Application Support/WiredSync/daemon/`
- **Proactive migration**: `ensureDaemonIsCurrentVersion()` now detects the old manually-managed LaunchAgent plist at startup and triggers the full migration automatically, even if the old daemon is still running. Previously the migration only fired on IPC connection failure, meaning an already-running legacy daemon would block the transition indefinitely.
- On first launch after update: old plist and daemon binary are removed, SMAppService takes over
- App updates work cleanly: send shutdown RPC → launchd's `KeepAlive` restarts wiredsyncd automatically with the new binary from the updated bundle

## Why SMAppService?

The old approach required the app to be running to bootstrap the daemon via `launchctl`, which meant sync would stop if the user quit Wired 3. `SMAppService` hands responsibility for the agent lifecycle to launchd, matching how other background sync tools (Dropbox, iCloud, etc.) work on macOS.

## Migration

Automatic on first launch after update:
1. Removes `~/Library/LaunchAgents/fr.read-write.wiredsyncd.plist` (old dynamic plist)
2. Removes `~/Library/Application Support/WiredSync/daemon/wiredsyncd` (old copied binary)
3. Registers via `SMAppService.agent(plistName:).register()`

Sync pairs and all user data in `~/Library/Application Support/WiredSync/` are untouched.

## Test plan

- [ ] Fresh install: wiredsyncd appears in Login Items after first launch
- [ ] Upgrade from pre-SMAppService build: old plist and binary removed automatically, daemon continues running from app bundle
- [ ] Quit Wired 3 — sync continues (check daemon log)
- [ ] Reboot — sync resumes automatically without opening Wired 3
- [ ] App update: shutdown RPC sent, launchd restarts daemon from new bundle path

🤖 Generated with [Claude Code](https://claude.com/claude-code)