### PR TITLE
ci(review): add automated Claude PR review workflow

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,76 @@
+name: Claude PR Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  review:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Claude Review
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          model: claude-sonnet-4-6
+          mode: review
+          direct_prompt: |
+            Tu es le relecteur officiel de **Wired Client** — le client macOS
+            natif du protocole Wired (chats, boards, fichiers, bookmarks, admin)
+            et son daemon de synchronisation `wiredsyncd`. La couche protocole
+            est fournie par le paquet local `../WiredSwift`.
+
+            Relis cette pull request avec trois priorités, dans cet ordre :
+
+            1. **Sécurité** :
+               - manipulation de credentials / mots de passe / keychain
+               - chemins de fichiers côté `wiredsyncd` et transferts UI :
+                 path traversal, symlinks, sortie du dossier de sync
+               - entitlements, sandbox macOS, permissions accordées à l'app
+               - usage de `URLSession` / réseau hors `WiredSwift` (s'il y en a)
+               - parsing de données reçues du serveur côté client
+               - `try!` / force-unwrap sur des entrées réseau ou disque
+               - injection SQL dans les caches GRDB locaux
+
+            2. **Philosophie du projet** :
+               - **Nom produit** : garder « Wired Client » dans les textes
+                 visibles par l'utilisateur (cf. CONTRIBUTING.md).
+               - **Compat protocole** : si la PR change la façon dont l'app
+                 parle au serveur (nouveaux champs, gating selon la version
+                 du pair…), les règles de `WiredSwift/COMPATIBILITY.md`
+                 s'appliquent des deux côtés du fil. Signale-le.
+               - Code Swift idiomatique, respect du style `.swiftlint.yml`
+                 (4 espaces, camelCase). Les fichiers anciens ont des règles
+                 relâchées — pas de croisade de refactor non demandée.
+               - Conventional commits (`feat(chat):`, `fix(files):`, etc.).
+               - PR focalisée : pas de cleanup non lié au changement.
+               - Simplicité avant abstraction.
+
+            3. **Qualité générale** — bugs probables, edge cases (déconnexion,
+               serveur lent, données absentes), thread-safety (main thread vs
+               background, surtout autour de `wiredsyncd` et de l'UI),
+               accessibilité macOS, tests manquants.
+
+            **Ton et style** :
+            - Bienveillant, encourageant, jamais condescendant. L'auteur a
+              passé du temps sur cette PR — souligne d'abord ce qui est bien
+              fait.
+            - Tutoie l'auteur, parle en français.
+            - Distingue clairement :
+              - 🔴 **Bloquant** — sécurité, sandbox cassée, fuite de données
+              - 🟡 **À corriger** — bugs, conventions, nom produit
+              - 💡 **Suggestion / question** — à discuter
+              - ✨ **Bien joué** — ce qui mérite d'être salué
+            - Si la PR est propre, dis-le franchement, pas de critique inventée.
+            - Sois concis : pas de paraphrase du diff, va aux points qui
+              comptent.
+            - Termine par un petit mot positif pour l'auteur.

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Claude Review
         uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           model: claude-sonnet-4-6
           mode: review
           direct_prompt: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,69 @@
+# CLAUDE.md — Wired Client (macOS)
+
+Notes pour Claude (et autres assistants IA) qui travaillent sur ce dépôt.
+
+## Ce que ce repo contient
+
+| Chemin | Rôle |
+|---|---|
+| `Wired 3/` | App macOS — UI native (chats, boards, fichiers, bookmarks, admin) |
+| `Wired 3Tests/` | Tests unitaires de l'app |
+| `Wired 3UITests/` | Tests UI |
+| `wiredsyncd/` | Daemon de synchronisation des dossiers, en arrière-plan |
+| `Wired-macOS.xcodeproj` | Projet Xcode |
+
+**Dépendance locale** : `Wired-macOS` consomme `WiredSwift` via le paquet local
+`../WiredSwift`. Les deux repos sont supposés clonés côte à côte.
+
+## Documentation déjà existante — lis-la avant d'agir
+
+| Fichier | Quand le consulter |
+|---|---|
+| [CONTRIBUTING.md](CONTRIBUTING.md) | Setup, style, tests, workflow PR |
+| [SECURITY.md](SECURITY.md) | Politique de signalement de vulnérabilité |
+| [README.md](README.md) | Vue d'ensemble, build, run |
+| [CHANGELOG.md](CHANGELOG.md) | Historique des changements |
+| `../WiredSwift/COMPATIBILITY.md` | **À lire dès que la PR change la façon dont l'app parle au serveur** |
+
+## Règles non négociables
+
+1. **Nom du produit** : conserver « Wired Client » dans les textes visibles
+   par l'utilisateur, sauf raison forte.
+2. **Compat protocole** : si la PR introduit de nouveaux champs / messages /
+   comportements gatés sur la version du pair, les règles de
+   `../WiredSwift/COMPATIBILITY.md` s'appliquent des deux côtés du fil.
+3. **Sécurité** : credentials/keychain, entitlements, sandbox macOS, chemins
+   de fichiers (`wiredsyncd` surtout). Pas de force-unwrap sur des entrées
+   réseau ou disque.
+4. **SwiftLint** : `swiftlint lint` doit passer. Les fichiers anciens ont des
+   règles intentionnellement relâchées — pas de croisade de refactor non
+   demandée.
+5. **Conventional Commits** : `feat(scope): …`. Scopes courants : `chat`,
+   `boards`, `files`, `messages`, `sync`, `ui`, `ci`, `docs`.
+6. **PR focalisée** : pas de cleanup non lié au changement.
+
+## Commandes utiles
+
+```bash
+# Lint
+swiftlint lint
+scripts/run-swiftlint-ci.sh all
+scripts/run-swiftlint-ci.sh changed <base-sha> <head-sha>
+
+# Tests app
+xcodebuild test \
+  -project "Wired-macOS.xcodeproj" \
+  -scheme "Wired 3 Unit Tests" \
+  -destination "platform=macOS" \
+  CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO
+
+# Tests wiredsyncd
+cd wiredsyncd && swift test
+```
+
+## Review automatique
+
+Les PR sont relues automatiquement par Claude (Sonnet 4.6) via
+[.github/workflows/claude-review.yml](.github/workflows/claude-review.yml).
+La review est indicative — elle ne bloque pas le merge. Le focus est :
+sécurité (credentials, sandbox, chemins), conventions du projet, qualité.


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/claude-review.yml` — runs the official `anthropics/claude-code-action` (Sonnet 4.6) on each PR open / sync / reopen, posting a single review comment focused on **security** (credentials, sandbox, file paths), product naming (« Wired Client »), and Wired protocol compatibility when relevant.
- Adds `CLAUDE.md` to orient AI-assisted contributions toward the existing docs (`CONTRIBUTING.md`, `SECURITY.md`, `../WiredSwift/COMPATIBILITY.md`).

## Setup required before this can run
Authenticated via Claude OAuth token (consumes the subscription quota instead of API billing).

1. Generate the token locally: `claude setup-token` (requires Claude Code CLI, signed into a Pro/Max/Team account)
2. Add a repository secret `CLAUDE_CODE_OAUTH_TOKEN` (Settings → Secrets and variables → Actions) with the token returned by the command

The workflow skips draft PRs.

## Test plan
- [ ] Generate and add the `CLAUDE_CODE_OAUTH_TOKEN` secret
- [ ] Merge this PR
- [ ] Open a small follow-up PR and confirm Claude posts a review comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)